### PR TITLE
Add Mermaid syntax guardrails to generation prompt

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -82,7 +82,8 @@ const TOOL_DEFINITION: Anthropic.Tool = {
       },
       diagram: {
         type: "string",
-        description: "Mermaid.js diagram showing the architecture (flowchart TD format)",
+        description:
+          "Mermaid.js flowchart TD diagram showing the architecture. MUST use valid syntax: quote node labels containing special characters, no classDef in subgraph declarations, no spaces inside pipe characters for edge labels, no subgraph aliases.",
       },
       buildSteps: {
         type: "array",
@@ -124,7 +125,22 @@ ${leaderboardContext}
 
 Based on this data, recommend a tech stack for the following project. Prefer tools with high momentum scores — they indicate strong community adoption and active development. But also consider maturity, fit for the use case, and practical considerations.
 
-Always include a Mermaid.js architecture diagram using flowchart TD format. Make it clean and readable.
+Generate a Mermaid.js architecture diagram using flowchart TD format. Follow these CRITICAL syntax rules:
+1. QUOTE all node labels containing special characters (parentheses, slashes, brackets, dots, ampersands).
+   CORRECT: A["API Gateway (/api)"]
+   WRONG: A[API Gateway (/api)]
+2. DO NOT apply classDef styles in subgraph declarations.
+   CORRECT: subgraph Frontend
+   WRONG: subgraph Frontend:::style
+3. NO spaces between pipe characters and edge labels.
+   CORRECT: A -->|"sends request"| B
+   WRONG: A -->| "sends request" | B
+4. DO NOT give subgraphs an alias like nodes.
+   CORRECT: subgraph "Backend Services"
+   WRONG: subgraph backend["Backend Services"]
+5. DO NOT include %%{init:...}%% directives — theme is handled externally.
+6. Use classDef to color-code different component types (databases, services, APIs, etc.).
+7. Keep the diagram primarily vertical (TD). Avoid long horizontal chains of nodes.
 
 Project description: ${prompt}`,
         },


### PR DESCRIPTION
## Summary
- Add 7 explicit Mermaid.js syntax rules to the architecture generation prompt to reduce broken diagram renders
- Reinforce the tool schema `diagram` field description with syntax requirements
- Rules cover the most common failure modes discovered in production: unquoted special chars, classDef in subgraphs, spaced pipe labels, subgraph aliases, init directives

## Inspiration
Inspired by patterns from [gitdiagram](https://github.com/ahmedkhaleel2004/gitdiagram), an open-source tool for generating architecture diagrams from GitHub repos. Their `SYSTEM_THIRD_PROMPT` contains battle-tested Mermaid syntax rules derived from observed LLM failure modes.

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Generate 5 different architectures and confirm diagrams render correctly (not falling back to `<pre>`)
- [ ] Verify diagrams use quoted labels for nodes with special characters
- [ ] Verify no `%%{init}%%` directives appear in generated diagrams

🤖 Generated with [Claude Code](https://claude.com/claude-code)