### PR TITLE
Add pan/zoom interactivity to architecture diagrams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "next": "^16.1.6",
         "postgres": "^3.4.5",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "svg-pan-zoom": "^3.6.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
@@ -9456,6 +9457,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/svg-pan-zoom": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/svg-pan-zoom/-/svg-pan-zoom-3.6.2.tgz",
+      "integrity": "sha512-JwnvRWfVKw/Xzfe6jriFyfey/lWJLq4bUh2jwoR5ChWQuQoOH8FEh1l/bEp46iHHKHEJWIyFJETbazraxNWECg==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "next": "^16.1.6",
     "postgres": "^3.4.5",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "svg-pan-zoom": "^3.6.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",

--- a/src/components/mermaid-diagram.tsx
+++ b/src/components/mermaid-diagram.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useCallback } from "react";
+import type SvgPanZoom from "svg-pan-zoom";
 
 function escapeHtml(str: string): string {
   return str
@@ -14,9 +15,17 @@ function escapeHtml(str: string): string {
 export function MermaidDiagram({ chart }: { chart: string }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const idRef = useRef(`mermaid-${Math.random().toString(36).slice(2, 9)}`);
+  const panZoomRef = useRef<SvgPanZoom.Instance | null>(null);
 
   const render = useCallback(async () => {
     if (!containerRef.current || !chart) return;
+
+    // Destroy existing pan-zoom instance before re-rendering
+    if (panZoomRef.current) {
+      panZoomRef.current.destroy();
+      panZoomRef.current = null;
+    }
+
     try {
       const mermaid = (await import("mermaid")).default;
       mermaid.initialize({
@@ -33,6 +42,31 @@ export function MermaidDiagram({ chart }: { chart: string }) {
       });
       const { svg } = await mermaid.render(idRef.current, chart);
       containerRef.current.innerHTML = svg;
+
+      // Attach pan-zoom after the SVG is in the DOM
+      requestAnimationFrame(async () => {
+        const svgElement = containerRef.current?.querySelector("svg");
+        if (!svgElement) return;
+
+        svgElement.style.maxWidth = "none";
+        svgElement.style.width = "100%";
+        svgElement.style.height = "100%";
+
+        try {
+          const svgPanZoom = (await import("svg-pan-zoom")).default;
+          panZoomRef.current = svgPanZoom(svgElement, {
+            zoomEnabled: true,
+            controlIconsEnabled: true,
+            fit: true,
+            center: true,
+            minZoom: 0.1,
+            maxZoom: 10,
+            zoomScaleSensitivity: 0.3,
+          });
+        } catch (err) {
+          console.error("svg-pan-zoom init error:", err);
+        }
+      });
     } catch (err) {
       console.error("Mermaid render error:", err);
       if (containerRef.current) {
@@ -43,12 +77,18 @@ export function MermaidDiagram({ chart }: { chart: string }) {
 
   useEffect(() => {
     render();
+    return () => {
+      if (panZoomRef.current) {
+        panZoomRef.current.destroy();
+        panZoomRef.current = null;
+      }
+    };
   }, [render]);
 
   return (
     <div
       ref={containerRef}
-      className="p-6 border border-zinc-800 rounded-xl bg-zinc-900/30 overflow-x-auto flex justify-center"
+      className="h-[500px] p-6 border border-zinc-800 rounded-xl bg-zinc-900/30 overflow-hidden flex justify-center"
     />
   );
 }


### PR DESCRIPTION
## Summary
- Integrate `svg-pan-zoom` into the `MermaidDiagram` component for scroll-to-zoom and click-drag panning
- Fixed 500px height container with zoom controls (zoom in/out/reset icons on the SVG)
- Proper cleanup: destroys pan-zoom instance on unmount and re-render to prevent memory leaks
- Dynamic import keeps bundle size minimal (~28KB, zero transitive deps)

## Inspiration
Inspired by [gitdiagram](https://github.com/ahmedkhaleel2004/gitdiagram)'s interactive diagram rendering with `svg-pan-zoom`, adapted to our existing dark theme and component structure.

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Generate an architecture — scroll-to-zoom works on the diagram
- [ ] Click-drag pans the diagram within the container
- [ ] Zoom control icons (bottom-right of SVG) are visible and functional
- [ ] Shared stack page (`/stack/[id]`) also has pan/zoom (same component)
- [ ] Fallback to `<pre>` still works when Mermaid render fails
- [ ] Navigate away and back — no console errors (cleanup works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)