### PR TITLE
Split generation into two-stage pipeline for better diagrams

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -13,6 +13,23 @@ export const maxDuration = 60;
 
 const anthropic = new Anthropic();
 
+const MERMAID_RULES = `Follow these CRITICAL Mermaid.js syntax rules:
+1. QUOTE all node labels containing special characters (parentheses, slashes, brackets, dots, ampersands).
+   CORRECT: A["API Gateway (/api)"]
+   WRONG: A[API Gateway (/api)]
+2. DO NOT apply classDef styles in subgraph declarations.
+   CORRECT: subgraph Frontend
+   WRONG: subgraph Frontend:::style
+3. NO spaces between pipe characters and edge labels.
+   CORRECT: A -->|"sends request"| B
+   WRONG: A -->| "sends request" | B
+4. DO NOT give subgraphs an alias like nodes.
+   CORRECT: subgraph "Backend Services"
+   WRONG: subgraph backend["Backend Services"]
+5. DO NOT include %%{init:...}%% directives — theme is handled externally.
+6. Use classDef to color-code different component types (databases, services, APIs, etc.).
+7. Keep the diagram primarily vertical (TD). Avoid long horizontal chains.`;
+
 async function getLeaderboardContext(): Promise<string> {
   const allTools = await db.select().from(tools);
 
@@ -54,9 +71,11 @@ async function getLeaderboardContext(): Promise<string> {
     .join("\n");
 }
 
-const TOOL_DEFINITION: Anthropic.Tool = {
-  name: "generate_architecture",
-  description: "Generate a recommended tech stack and architecture for a project",
+// Stage 1: Select tools and describe architecture (no diagram generation)
+const STAGE1_TOOL: Anthropic.Tool = {
+  name: "describe_architecture",
+  description:
+    "Describe the recommended architecture, select tools, and provide build guidance",
   input_schema: {
     type: "object" as const,
     properties: {
@@ -77,17 +96,18 @@ const TOOL_DEFINITION: Anthropic.Tool = {
             },
             reason: {
               type: "string",
-              description: "Why this tool is recommended, referencing momentum data",
+              description:
+                "Why this tool is recommended, referencing momentum data",
             },
           },
           required: ["name", "category", "reason"],
         },
         description: "Recommended tools for the stack",
       },
-      diagram: {
+      diagramDescription: {
         type: "string",
         description:
-          "Mermaid.js flowchart TD diagram showing the architecture. MUST use valid syntax: quote node labels containing special characters, no classDef in subgraph declarations, no spaces inside pipe characters for edge labels, no subgraph aliases.",
+          "Detailed description of what the architecture diagram should show: all components, subgraphs/layers, data flow directions, and relationships between services. Be specific about node names and connection labels.",
       },
       buildSteps: {
         type: "array",
@@ -100,9 +120,67 @@ const TOOL_DEFINITION: Anthropic.Tool = {
         description: "Key tradeoffs and considerations for this architecture",
       },
     },
-    required: ["summary", "tools", "diagram", "buildSteps", "tradeoffs"],
+    required: [
+      "summary",
+      "tools",
+      "diagramDescription",
+      "buildSteps",
+      "tradeoffs",
+    ],
   },
 };
+
+async function repairDiagram(diagram: string): Promise<string> {
+  const validation = await validateMermaidSyntax(diagram);
+  if (validation.valid) return diagram;
+
+  const MAX_FIX_ATTEMPTS = 3;
+  let current = diagram;
+
+  for (let attempt = 1; attempt <= MAX_FIX_ATTEMPTS; attempt++) {
+    console.log(
+      `Mermaid repair attempt ${attempt}/${MAX_FIX_ATTEMPTS}: ${validation.error}`
+    );
+    const fixResponse = await anthropic.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 2048,
+      messages: [
+        {
+          role: "user",
+          content: `Fix this Mermaid.js diagram syntax error. Return ONLY the corrected Mermaid code — no explanation, no markdown fences.
+
+Broken diagram:
+${current}
+
+Parser error:
+${validation.error}
+
+${MERMAID_RULES}
+Keep the diagram meaning and structure intact. Only fix the syntax.`,
+        },
+      ],
+    });
+
+    const fixedText = fixResponse.content
+      .filter((b): b is Anthropic.TextBlock => b.type === "text")
+      .map((b) => b.text)
+      .join("");
+    current = stripMermaidCodeFences(fixedText);
+
+    const revalidation = await validateMermaidSyntax(current);
+    if (revalidation.valid) {
+      console.log(`Mermaid repair succeeded on attempt ${attempt}`);
+      return current;
+    }
+    if (attempt === MAX_FIX_ATTEMPTS) {
+      console.warn(
+        "Mermaid repair failed after max attempts, using last attempt"
+      );
+    }
+  }
+
+  return current;
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -114,11 +192,12 @@ export async function POST(request: NextRequest) {
 
     const leaderboardContext = await getLeaderboardContext();
 
-    const response = await anthropic.messages.create({
+    // Stage 1: Select tools and describe the architecture
+    const stage1Response = await anthropic.messages.create({
       model: "claude-sonnet-4-20250514",
-      max_tokens: 4096,
-      tools: [TOOL_DEFINITION],
-      tool_choice: { type: "tool", name: "generate_architecture" },
+      max_tokens: 3072,
+      tools: [STAGE1_TOOL],
+      tool_choice: { type: "tool", name: "describe_architecture" },
       messages: [
         {
           role: "user",
@@ -129,97 +208,69 @@ ${leaderboardContext}
 
 Based on this data, recommend a tech stack for the following project. Prefer tools with high momentum scores — they indicate strong community adoption and active development. But also consider maturity, fit for the use case, and practical considerations.
 
-Generate a Mermaid.js architecture diagram using flowchart TD format. Follow these CRITICAL syntax rules:
-1. QUOTE all node labels containing special characters (parentheses, slashes, brackets, dots, ampersands).
-   CORRECT: A["API Gateway (/api)"]
-   WRONG: A[API Gateway (/api)]
-2. DO NOT apply classDef styles in subgraph declarations.
-   CORRECT: subgraph Frontend
-   WRONG: subgraph Frontend:::style
-3. NO spaces between pipe characters and edge labels.
-   CORRECT: A -->|"sends request"| B
-   WRONG: A -->| "sends request" | B
-4. DO NOT give subgraphs an alias like nodes.
-   CORRECT: subgraph "Backend Services"
-   WRONG: subgraph backend["Backend Services"]
-5. DO NOT include %%{init:...}%% directives — theme is handled externally.
-6. Use classDef to color-code different component types (databases, services, APIs, etc.).
-7. Keep the diagram primarily vertical (TD). Avoid long horizontal chains of nodes.
+In your diagramDescription, be very detailed about the architecture: list every component, which subgraphs/layers they belong to, how data flows between them, and what each connection represents. This description will be used to generate a Mermaid diagram in a separate step.
 
 Project description: ${prompt}`,
         },
       ],
     });
 
-    // Extract the tool use result
-    const toolUseBlock = response.content.find(
+    const stage1Block = stage1Response.content.find(
       (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
     );
 
-    if (!toolUseBlock) {
+    if (!stage1Block) {
       return NextResponse.json(
         { error: "Failed to generate architecture" },
         { status: 500 }
       );
     }
 
-    const result = toolUseBlock.input as Record<string, unknown>;
-    let diagram = stripMermaidCodeFences(String(result.diagram ?? ""));
+    const stage1 = stage1Block.input as {
+      summary: string;
+      tools: Array<{ name: string; category: string; reason: string }>;
+      diagramDescription: string;
+      buildSteps: string[];
+      tradeoffs: string[];
+    };
 
-    // Validate Mermaid syntax and attempt auto-repair if invalid
-    const validation = await validateMermaidSyntax(diagram);
-    if (!validation.valid) {
-      const MAX_FIX_ATTEMPTS = 3;
-      for (let attempt = 1; attempt <= MAX_FIX_ATTEMPTS; attempt++) {
-        console.log(
-          `Mermaid repair attempt ${attempt}/${MAX_FIX_ATTEMPTS}: ${validation.error}`
-        );
-        const fixResponse = await anthropic.messages.create({
-          model: "claude-sonnet-4-20250514",
-          max_tokens: 2048,
-          messages: [
-            {
-              role: "user",
-              content: `Fix this Mermaid.js diagram syntax error. Return ONLY the corrected Mermaid code — no explanation, no markdown fences.
+    // Stage 2: Generate Mermaid diagram from the architecture description
+    const stage2Response = await anthropic.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 2048,
+      messages: [
+        {
+          role: "user",
+          content: `Generate a Mermaid.js flowchart TD diagram based on this architecture description. Return ONLY valid Mermaid.js code — no explanation, no markdown fences, no commentary.
 
-Broken diagram:
-${diagram}
+Architecture:
+${stage1.diagramDescription}
 
-Parser error:
-${validation.error}
+Tools in the stack: ${stage1.tools.map((t) => t.name).join(", ")}
 
-Syntax rules to follow:
-1. Quote all node labels containing special characters (parentheses, slashes, brackets, dots).
-2. Do not apply classDef styles in subgraph declarations.
-3. No spaces between pipe characters and edge labels.
-4. Do not give subgraphs an alias.
-5. Do not include %%{init:...}%% directives.
-Keep the diagram meaning and structure intact. Only fix the syntax.`,
-            },
-          ],
-        });
+${MERMAID_RULES}`,
+        },
+      ],
+    });
 
-        const fixedText = fixResponse.content
-          .filter((b): b is Anthropic.TextBlock => b.type === "text")
-          .map((b) => b.text)
-          .join("");
-        diagram = stripMermaidCodeFences(fixedText);
+    const diagramText = stage2Response.content
+      .filter((b): b is Anthropic.TextBlock => b.type === "text")
+      .map((b) => b.text)
+      .join("");
+    let diagram = stripMermaidCodeFences(diagramText);
 
-        const revalidation = await validateMermaidSyntax(diagram);
-        if (revalidation.valid) {
-          console.log(`Mermaid repair succeeded on attempt ${attempt}`);
-          break;
-        }
-        if (attempt === MAX_FIX_ATTEMPTS) {
-          console.warn(
-            "Mermaid repair failed after max attempts, using last attempt"
-          );
-        }
-      }
-    }
+    // Validate and repair if needed
+    diagram = await repairDiagram(diagram);
 
-    result.diagram = diagram;
-    return NextResponse.json({ result });
+    return NextResponse.json({
+      result: {
+        summary: stage1.summary,
+        tools: stage1.tools,
+        diagram,
+        buildSteps: stage1.buildSteps,
+        tradeoffs: stage1.tradeoffs,
+      },
+    });
   } catch (error) {
     console.error("Generate API error:", error);
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- **Stage 1** (tool_use): Selects tools, writes summary, build steps, tradeoffs, and a detailed `diagramDescription` — no Mermaid code
- **Stage 2** (plain text): Takes the architecture description + tool names and generates focused Mermaid flowchart code
- Extracts `MERMAID_RULES` constant and `repairDiagram()` helper for reuse
- Same response shape (`ArchResult`) — fully backward compatible with the frontend

## Why two stages?
Asking Claude to simultaneously pick tools, reason about architecture, AND produce valid Mermaid syntax in one call degrades all three outputs. gitdiagram discovered this same issue and split into 3 stages. We split into 2 (we don't need their file-path mapping stage).

## Inspiration
Inspired by [gitdiagram](https://github.com/ahmedkhaleel2004/gitdiagram)'s multi-stage pipeline design.

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Generate same prompt 3-5 times — diagrams should be more detailed and accurate than before
- [ ] End-to-end latency is acceptable (~12-18s for two calls)
- [ ] Response shape unchanged — sharing, markdown export, diagram rendering all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)