### PR TITLE
Add SSE streaming with progressive generation UI

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -7,6 +7,7 @@ import {
   validateMermaidSyntax,
   stripMermaidCodeFences,
 } from "@/lib/mermaid-validate";
+import { sseMessage } from "@/lib/sse";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -130,7 +131,18 @@ const STAGE1_TOOL: Anthropic.Tool = {
   },
 };
 
-async function repairDiagram(diagram: string): Promise<string> {
+interface Stage1Result {
+  summary: string;
+  tools: Array<{ name: string; category: string; reason: string }>;
+  diagramDescription: string;
+  buildSteps: string[];
+  tradeoffs: string[];
+}
+
+async function repairDiagram(
+  diagram: string,
+  send: (payload: Record<string, unknown>) => void
+): Promise<string> {
   const validation = await validateMermaidSyntax(diagram);
   if (validation.valid) return diagram;
 
@@ -138,6 +150,10 @@ async function repairDiagram(diagram: string): Promise<string> {
   let current = diagram;
 
   for (let attempt = 1; attempt <= MAX_FIX_ATTEMPTS; attempt++) {
+    send({
+      status: "repairing_diagram",
+      message: `Repairing diagram syntax (attempt ${attempt}/${MAX_FIX_ATTEMPTS})...`,
+    });
     console.log(
       `Mermaid repair attempt ${attempt}/${MAX_FIX_ATTEMPTS}: ${validation.error}`
     );
@@ -183,25 +199,39 @@ Keep the diagram meaning and structure intact. Only fix the syntax.`,
 }
 
 export async function POST(request: NextRequest) {
-  try {
-    const { prompt } = await request.json();
+  const body = await request.json();
+  const { prompt } = body;
 
-    if (!prompt || typeof prompt !== "string" || prompt.length > 2000) {
-      return NextResponse.json({ error: "Invalid prompt" }, { status: 400 });
-    }
+  if (!prompt || typeof prompt !== "string" || prompt.length > 2000) {
+    return NextResponse.json({ error: "Invalid prompt" }, { status: 400 });
+  }
 
-    const leaderboardContext = await getLeaderboardContext();
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = (payload: Record<string, unknown>) => {
+        controller.enqueue(encoder.encode(sseMessage(payload)));
+      };
 
-    // Stage 1: Select tools and describe the architecture
-    const stage1Response = await anthropic.messages.create({
-      model: "claude-sonnet-4-20250514",
-      max_tokens: 3072,
-      tools: [STAGE1_TOOL],
-      tool_choice: { type: "tool", name: "describe_architecture" },
-      messages: [
-        {
-          role: "user",
-          content: `You are an AI architecture advisor. You have access to live developer sentiment data that tracks which AI/dev tools are gaining momentum right now.
+      try {
+        send({ status: "started", message: "Fetching leaderboard context..." });
+        const leaderboardContext = await getLeaderboardContext();
+
+        // Stage 1: Select tools and describe the architecture
+        send({
+          status: "selecting_tools",
+          message: "Selecting tools and designing architecture...",
+        });
+
+        const stage1Response = await anthropic.messages.create({
+          model: "claude-sonnet-4-20250514",
+          max_tokens: 3072,
+          tools: [STAGE1_TOOL],
+          tool_choice: { type: "tool", name: "describe_architecture" },
+          messages: [
+            {
+              role: "user",
+              content: `You are an AI architecture advisor. You have access to live developer sentiment data that tracks which AI/dev tools are gaining momentum right now.
 
 Here is the current momentum leaderboard (sorted by overall momentum score):
 ${leaderboardContext}
@@ -211,37 +241,40 @@ Based on this data, recommend a tech stack for the following project. Prefer too
 In your diagramDescription, be very detailed about the architecture: list every component, which subgraphs/layers they belong to, how data flows between them, and what each connection represents. This description will be used to generate a Mermaid diagram in a separate step.
 
 Project description: ${prompt}`,
-        },
-      ],
-    });
+            },
+          ],
+        });
 
-    const stage1Block = stage1Response.content.find(
-      (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
-    );
+        const stage1Block = stage1Response.content.find(
+          (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
+        );
 
-    if (!stage1Block) {
-      return NextResponse.json(
-        { error: "Failed to generate architecture" },
-        { status: 500 }
-      );
-    }
+        if (!stage1Block) {
+          send({ status: "error", error: "Failed to generate architecture" });
+          controller.close();
+          return;
+        }
 
-    const stage1 = stage1Block.input as {
-      summary: string;
-      tools: Array<{ name: string; category: string; reason: string }>;
-      diagramDescription: string;
-      buildSteps: string[];
-      tradeoffs: string[];
-    };
+        const stage1 = stage1Block.input as Stage1Result;
 
-    // Stage 2: Generate Mermaid diagram from the architecture description
-    const stage2Response = await anthropic.messages.create({
-      model: "claude-sonnet-4-20250514",
-      max_tokens: 2048,
-      messages: [
-        {
-          role: "user",
-          content: `Generate a Mermaid.js flowchart TD diagram based on this architecture description. Return ONLY valid Mermaid.js code — no explanation, no markdown fences, no commentary.
+        send({
+          status: "tools_complete",
+          message: "Architecture designed. Generating diagram...",
+        });
+
+        // Stage 2: Generate Mermaid diagram from the architecture description
+        send({
+          status: "generating_diagram",
+          message: "Generating Mermaid diagram...",
+        });
+
+        const stage2Response = await anthropic.messages.create({
+          model: "claude-sonnet-4-20250514",
+          max_tokens: 2048,
+          messages: [
+            {
+              role: "user",
+              content: `Generate a Mermaid.js flowchart TD diagram based on this architecture description. Return ONLY valid Mermaid.js code — no explanation, no markdown fences, no commentary.
 
 Architecture:
 ${stage1.diagramDescription}
@@ -249,33 +282,47 @@ ${stage1.diagramDescription}
 Tools in the stack: ${stage1.tools.map((t) => t.name).join(", ")}
 
 ${MERMAID_RULES}`,
-        },
-      ],
-    });
+            },
+          ],
+        });
 
-    const diagramText = stage2Response.content
-      .filter((b): b is Anthropic.TextBlock => b.type === "text")
-      .map((b) => b.text)
-      .join("");
-    let diagram = stripMermaidCodeFences(diagramText);
+        const diagramText = stage2Response.content
+          .filter((b): b is Anthropic.TextBlock => b.type === "text")
+          .map((b) => b.text)
+          .join("");
+        let diagram = stripMermaidCodeFences(diagramText);
 
-    // Validate and repair if needed
-    diagram = await repairDiagram(diagram);
+        // Validate and repair if needed
+        send({
+          status: "validating_diagram",
+          message: "Validating diagram syntax...",
+        });
+        diagram = await repairDiagram(diagram, send);
 
-    return NextResponse.json({
-      result: {
-        summary: stage1.summary,
-        tools: stage1.tools,
-        diagram,
-        buildSteps: stage1.buildSteps,
-        tradeoffs: stage1.tradeoffs,
-      },
-    });
-  } catch (error) {
-    console.error("Generate API error:", error);
-    return NextResponse.json(
-      { error: "Failed to generate architecture" },
-      { status: 500 }
-    );
-  }
+        send({
+          status: "complete",
+          result: {
+            summary: stage1.summary,
+            tools: stage1.tools,
+            diagram,
+            buildSteps: stage1.buildSteps,
+            tradeoffs: stage1.tradeoffs,
+          },
+        });
+      } catch (error) {
+        console.error("Generate API error:", error);
+        send({ status: "error", error: "Failed to generate architecture" });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
 }

--- a/src/components/architecture-generator.tsx
+++ b/src/components/architecture-generator.tsx
@@ -15,20 +15,14 @@ import {
   Bot,
   Server,
   Workflow,
+  CheckCircle2,
+  Circle,
 } from "lucide-react";
 import { MermaidDiagram } from "@/components/mermaid-diagram";
-
-interface ArchResult {
-  summary: string;
-  tools: Array<{
-    name: string;
-    category: string;
-    reason: string;
-  }>;
-  diagram: string;
-  buildSteps: string[];
-  tradeoffs: string[];
-}
+import {
+  useGenerateStream,
+  type GenerateStatus,
+} from "@/hooks/useGenerateStream";
 
 const QUICK_PROMPTS = [
   {
@@ -57,83 +51,98 @@ const QUICK_PROMPTS = [
   },
 ];
 
-function SkeletonLoader() {
+const GENERATION_STAGES: Array<{
+  key: GenerateStatus;
+  label: string;
+}> = [
+  { key: "selecting_tools", label: "Designing architecture" },
+  { key: "generating_diagram", label: "Generating diagram" },
+  { key: "validating_diagram", label: "Validating diagram" },
+];
+
+function getStageState(
+  stageKey: GenerateStatus,
+  currentStatus: GenerateStatus
+): "completed" | "active" | "pending" {
+  const order: GenerateStatus[] = [
+    "started",
+    "selecting_tools",
+    "tools_complete",
+    "generating_diagram",
+    "validating_diagram",
+    "repairing_diagram",
+    "complete",
+  ];
+  const currentIdx = order.indexOf(currentStatus);
+  const stageIdx = order.indexOf(stageKey);
+
+  if (currentIdx > stageIdx) return "completed";
+  if (currentIdx === stageIdx) return "active";
+  // tools_complete is between selecting_tools and generating_diagram
+  if (stageKey === "selecting_tools" && currentStatus === "tools_complete")
+    return "completed";
+  if (stageKey === "validating_diagram" && currentStatus === "repairing_diagram")
+    return "active";
+  return "pending";
+}
+
+function GenerationProgress({
+  status,
+  message,
+}: {
+  status: GenerateStatus;
+  message: string;
+}) {
   return (
-    <div className="mt-8 space-y-8 animate-pulse">
-      {/* Summary skeleton */}
-      <div className="space-y-2">
-        <div className="h-4 bg-zinc-800 rounded-lg w-3/4" />
-        <div className="h-4 bg-zinc-800 rounded-lg w-1/2" />
-      </div>
-
-      {/* Tools skeleton */}
-      <div>
-        <div className="h-5 bg-zinc-800 rounded-lg w-40 mb-4" />
-        <div className="space-y-3">
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="p-4 border border-zinc-800 rounded-xl">
-              <div className="h-4 bg-zinc-800 rounded w-48 mb-2" />
-              <div className="h-3 bg-zinc-800/60 rounded w-full" />
+    <div className="mt-8 p-6 border border-zinc-800 rounded-xl bg-zinc-900/30">
+      <div className="space-y-4">
+        {GENERATION_STAGES.map((stage) => {
+          const state = getStageState(stage.key, status);
+          return (
+            <div key={stage.key} className="flex items-center gap-3">
+              {state === "completed" ? (
+                <CheckCircle2 className="w-5 h-5 text-emerald-400 shrink-0" />
+              ) : state === "active" ? (
+                <Loader2 className="w-5 h-5 text-white animate-spin shrink-0" />
+              ) : (
+                <Circle className="w-5 h-5 text-zinc-700 shrink-0" />
+              )}
+              <span
+                className={
+                  state === "completed"
+                    ? "text-zinc-400"
+                    : state === "active"
+                      ? "text-white font-medium"
+                      : "text-zinc-600"
+                }
+              >
+                {stage.label}
+              </span>
             </div>
-          ))}
-        </div>
+          );
+        })}
       </div>
-
-      {/* Diagram skeleton */}
-      <div>
-        <div className="h-5 bg-zinc-800 rounded-lg w-48 mb-4" />
-        <div className="h-64 border border-zinc-800 rounded-xl bg-zinc-900/30" />
-      </div>
-
-      {/* Build steps skeleton */}
-      <div>
-        <div className="h-5 bg-zinc-800 rounded-lg w-32 mb-4" />
-        <div className="space-y-3">
-          {[1, 2, 3, 4, 5].map((i) => (
-            <div key={i} className="flex gap-3">
-              <div className="w-7 h-7 rounded-full bg-zinc-800 shrink-0" />
-              <div className="h-4 bg-zinc-800/60 rounded w-full mt-1" />
-            </div>
-          ))}
-        </div>
-      </div>
+      <p className="mt-4 text-sm text-zinc-500">{message}</p>
     </div>
   );
 }
 
 export function ArchitectureGenerator() {
   const [prompt, setPrompt] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<ArchResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const { state, generate } = useGenerateStream();
+
+  const loading =
+    state.status !== "idle" &&
+    state.status !== "complete" &&
+    state.status !== "error";
+  const result = state.result;
 
   async function handleGenerate() {
     if (!prompt.trim()) return;
-    setLoading(true);
-    setError(null);
-    setResult(null);
     setShareUrl(null);
-
-    try {
-      const res = await fetch("/api/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ prompt: prompt.trim() }),
-      });
-
-      if (!res.ok) {
-        throw new Error("Failed to generate architecture");
-      }
-
-      const data = await res.json();
-      setResult(data.result);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Something went wrong");
-    } finally {
-      setLoading(false);
-    }
+    generate(prompt);
   }
 
   async function handleCopyMarkdown() {
@@ -240,14 +249,16 @@ Generated by [AI Stack Radar](https://ai-stack-radar.vercel.app) — architectur
         </div>
       </div>
 
-      {error && (
+      {state.status === "error" && (
         <div className="mt-6 p-4 bg-red-950/50 border border-red-900 rounded-xl text-red-300 text-sm">
-          {error}
+          {state.error}
         </div>
       )}
 
-      {/* Skeleton loader */}
-      {loading && <SkeletonLoader />}
+      {/* Progressive generation status */}
+      {loading && (
+        <GenerationProgress status={state.status} message={state.message} />
+      )}
 
       {/* Results */}
       {result && (

--- a/src/hooks/useGenerateStream.ts
+++ b/src/hooks/useGenerateStream.ts
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { parseSSEBuffer, type SSEMessage } from "@/lib/sse";
+
+export type GenerateStatus =
+  | "idle"
+  | "started"
+  | "selecting_tools"
+  | "tools_complete"
+  | "generating_diagram"
+  | "validating_diagram"
+  | "repairing_diagram"
+  | "complete"
+  | "error";
+
+interface ArchResult {
+  summary: string;
+  tools: Array<{ name: string; category: string; reason: string }>;
+  diagram: string;
+  buildSteps: string[];
+  tradeoffs: string[];
+}
+
+interface GenerateStreamState {
+  status: GenerateStatus;
+  message: string;
+  result: ArchResult | null;
+  error: string | null;
+}
+
+const STATUS_MESSAGES: Record<string, string> = {
+  started: "Fetching leaderboard context...",
+  selecting_tools: "Selecting tools and designing architecture...",
+  tools_complete: "Architecture designed. Generating diagram...",
+  generating_diagram: "Generating Mermaid diagram...",
+  validating_diagram: "Validating diagram syntax...",
+  repairing_diagram: "Repairing diagram syntax...",
+  complete: "Done!",
+};
+
+export function useGenerateStream() {
+  const [state, setState] = useState<GenerateStreamState>({
+    status: "idle",
+    message: "",
+    result: null,
+    error: null,
+  });
+
+  const generate = useCallback(async (prompt: string) => {
+    setState({
+      status: "started",
+      message: "Starting...",
+      result: null,
+      error: null,
+    });
+
+    try {
+      const response = await fetch("/api/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: prompt.trim() }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.error ?? "Failed to generate architecture");
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error("No response body");
+      }
+
+      let buffer = "";
+      const decoder = new TextDecoder();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const { messages, remainder } = parseSSEBuffer(buffer);
+        buffer = remainder;
+
+        for (const msg of messages) {
+          handleMessage(msg, setState);
+        }
+      }
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        status: "error",
+        error: err instanceof Error ? err.message : "Something went wrong",
+      }));
+    }
+  }, []);
+
+  return { state, generate };
+}
+
+function handleMessage(
+  msg: SSEMessage,
+  setState: React.Dispatch<React.SetStateAction<GenerateStreamState>>
+) {
+  if (msg.status === "error") {
+    setState((prev) => ({
+      ...prev,
+      status: "error",
+      error: msg.error ?? "Generation failed",
+    }));
+    return;
+  }
+
+  if (msg.status === "complete" && msg.result) {
+    setState({
+      status: "complete",
+      message: "Done!",
+      result: msg.result,
+      error: null,
+    });
+    return;
+  }
+
+  setState((prev) => ({
+    ...prev,
+    status: msg.status as GenerateStatus,
+    message:
+      msg.message ?? STATUS_MESSAGES[msg.status] ?? prev.message,
+  }));
+}

--- a/src/lib/sse.ts
+++ b/src/lib/sse.ts
@@ -1,0 +1,39 @@
+export function sseMessage(payload: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+export interface SSEMessage {
+  status: string;
+  message?: string;
+  result?: {
+    summary: string;
+    tools: Array<{ name: string; category: string; reason: string }>;
+    diagram: string;
+    buildSteps: string[];
+    tradeoffs: string[];
+  };
+  error?: string;
+}
+
+export function parseSSEBuffer(buffer: string): {
+  messages: SSEMessage[];
+  remainder: string;
+} {
+  const messages: SSEMessage[] = [];
+  const parts = buffer.split("\n\n");
+  const remainder = parts.pop() ?? "";
+
+  for (const part of parts) {
+    if (!part.trim()) continue;
+    for (const line of part.split("\n")) {
+      if (!line.startsWith("data:")) continue;
+      try {
+        messages.push(JSON.parse(line.slice(5).trim()) as SSEMessage);
+      } catch {
+        // skip malformed events
+      }
+    }
+  }
+
+  return { messages, remainder };
+}


### PR DESCRIPTION
## Summary
- **API**: Returns `text/event-stream` instead of JSON. Streams status events at each generation stage: `started` → `selecting_tools` → `tools_complete` → `generating_diagram` → `validating_diagram` → `repairing_diagram` (if needed) → `complete`
- **`src/lib/sse.ts`**: Shared SSE message formatter (server) and buffer parser (client) with remainder tracking for incomplete chunks
- **`src/hooks/useGenerateStream.ts`**: Client hook that consumes the SSE stream via `ReadableStream` reader, maps status events to UI state
- **`src/components/architecture-generator.tsx`**: Replaces skeleton loader with a step-by-step progress indicator showing completed (✓), active (spinner), and pending stages. Results render on `complete` event exactly as before

## Inspiration
Inspired by [gitdiagram](https://github.com/ahmedkhaleel2004/gitdiagram)'s SSE streaming with per-stage status events and `useDiagramStream` client hook.

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Generate a stack — progress indicator shows each stage updating in real-time
- [ ] Error handling: bad prompt returns error message immediately
- [ ] Results render identically to before (sharing, markdown export, diagram all work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)