### PR TITLE
Add GitHub repo stack health analysis feature

### DIFF
--- a/src/app/analyze/page.tsx
+++ b/src/app/analyze/page.tsx
@@ -1,0 +1,18 @@
+import { RepoAnalyzer } from "@/components/repo-analyzer";
+
+export default function AnalyzePage() {
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-12">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight">Stack Health Check</h1>
+        <p className="text-zinc-400 mt-2">
+          Paste a GitHub repo URL to analyze its dependencies against the
+          momentum leaderboard. See what&apos;s accelerating, what&apos;s
+          stagnating, and where to upgrade.
+        </p>
+      </div>
+
+      <RepoAnalyzer />
+    </div>
+  );
+}

--- a/src/app/api/analyze-repo/route.ts
+++ b/src/app/api/analyze-repo/route.ts
@@ -1,0 +1,350 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { db } from "@/lib/db";
+import { tools, momentumScores, githubSnapshots } from "@/lib/schema";
+import { desc, eq } from "drizzle-orm";
+import {
+  validateMermaidSyntax,
+  stripMermaidCodeFences,
+} from "@/lib/mermaid-validate";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const anthropic = new Anthropic();
+
+function parseGitHubUrl(
+  url: string
+): { owner: string; repo: string } | null {
+  const match = url.match(
+    /(?:https?:\/\/)?(?:www\.)?github\.com\/([^/\s]+)\/([^/\s#?]+)/
+  );
+  if (!match) return null;
+  return { owner: match[1], repo: match[2].replace(/\.git$/, "") };
+}
+
+async function fetchFileContent(
+  owner: string,
+  repo: string,
+  path: string
+): Promise<string | null> {
+  const token = process.env.GITHUB_TOKEN;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "ai-stack-radar",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
+      { headers }
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (data.encoding === "base64" && data.content) {
+      return Buffer.from(data.content, "base64").toString("utf-8");
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function extractNpmDeps(packageJsonStr: string): string[] {
+  try {
+    const pkg = JSON.parse(packageJsonStr);
+    return [
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.devDependencies ?? {}),
+    ];
+  } catch {
+    return [];
+  }
+}
+
+function extractPythonDeps(requirementsTxt: string): string[] {
+  return requirementsTxt
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#") && !line.startsWith("-"))
+    .map((line) => line.split(/[=<>!~[\s]/)[0].toLowerCase());
+}
+
+function extractPyprojectDeps(pyprojectToml: string): string[] {
+  const deps: string[] = [];
+  const depSection = pyprojectToml.match(
+    /\[(?:project\.)?dependencies\]\s*\n([\s\S]*?)(?:\n\[|\n$)/
+  );
+  if (depSection) {
+    for (const line of depSection[1].split("\n")) {
+      const trimmed = line.trim().replace(/^["']|["'].*$/g, "");
+      if (trimmed && !trimmed.startsWith("#")) {
+        deps.push(trimmed.split(/[=<>!~[\s]/)[0].toLowerCase());
+      }
+    }
+  }
+  // Also check for array-style dependencies
+  const arrayMatch = pyprojectToml.match(
+    /dependencies\s*=\s*\[([\s\S]*?)\]/
+  );
+  if (arrayMatch) {
+    for (const match of arrayMatch[1].matchAll(/"([^"]+)"|'([^']+)'/g)) {
+      const dep = (match[1] || match[2]).split(/[=<>!~[\s]/)[0].toLowerCase();
+      if (dep) deps.push(dep);
+    }
+  }
+  return [...new Set(deps)];
+}
+
+const ANALYSIS_TOOL: Anthropic.Tool = {
+  name: "analyze_stack",
+  description: "Analyze a repository's tech stack against momentum data",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      summary: {
+        type: "string",
+        description:
+          "2-3 sentence overview of the project's tech stack and its health",
+      },
+      overallHealthScore: {
+        type: "number",
+        description:
+          "Overall stack health score from 0-100 based on momentum of detected tools",
+      },
+      detectedTools: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            category: { type: "string" },
+            status: {
+              type: "string",
+              enum: ["accelerating", "stable", "stagnating"],
+              description:
+                "Tool momentum status based on velocity and community activity",
+            },
+            momentumScore: {
+              type: "number",
+              description: "Momentum score from our leaderboard, or 0 if not tracked",
+            },
+            note: {
+              type: "string",
+              description: "Brief note about this tool's trajectory",
+            },
+          },
+          required: ["name", "category", "status", "momentumScore", "note"],
+        },
+      },
+      suggestions: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            current: {
+              type: "string",
+              description: "Current tool or gap in the stack",
+            },
+            suggested: {
+              type: "string",
+              description: "Suggested tool to adopt or switch to",
+            },
+            reason: {
+              type: "string",
+              description:
+                "Why this change is recommended, referencing momentum data",
+            },
+          },
+          required: ["current", "suggested", "reason"],
+        },
+        description: "Suggested upgrades or additions to the stack",
+      },
+      diagram: {
+        type: "string",
+        description:
+          "Mermaid.js flowchart TD showing the current architecture with tools color-coded by momentum status",
+      },
+    },
+    required: [
+      "summary",
+      "overallHealthScore",
+      "detectedTools",
+      "suggestions",
+      "diagram",
+    ],
+  },
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const { repoUrl } = await request.json();
+
+    if (!repoUrl || typeof repoUrl !== "string") {
+      return NextResponse.json(
+        { error: "GitHub repo URL is required" },
+        { status: 400 }
+      );
+    }
+
+    const parsed = parseGitHubUrl(repoUrl);
+    if (!parsed) {
+      return NextResponse.json(
+        { error: "Invalid GitHub URL. Expected format: https://github.com/owner/repo" },
+        { status: 400 }
+      );
+    }
+
+    // Fetch dependency files in parallel
+    const [packageJson, requirementsTxt, pyprojectToml] = await Promise.all([
+      fetchFileContent(parsed.owner, parsed.repo, "package.json"),
+      fetchFileContent(parsed.owner, parsed.repo, "requirements.txt"),
+      fetchFileContent(parsed.owner, parsed.repo, "pyproject.toml"),
+    ]);
+
+    if (!packageJson && !requirementsTxt && !pyprojectToml) {
+      return NextResponse.json(
+        {
+          error:
+            "Could not find dependency files (package.json, requirements.txt, or pyproject.toml). Is this a public repo?",
+        },
+        { status: 404 }
+      );
+    }
+
+    // Extract dependencies
+    const allDeps: string[] = [];
+    if (packageJson) allDeps.push(...extractNpmDeps(packageJson));
+    if (requirementsTxt) allDeps.push(...extractPythonDeps(requirementsTxt));
+    if (pyprojectToml) allDeps.push(...extractPyprojectDeps(pyprojectToml));
+
+    // Get all tools with their momentum data
+    const allTools = await db.select().from(tools);
+    const toolsWithScores = await Promise.all(
+      allTools.map(async (tool) => {
+        const [score] = await db
+          .select()
+          .from(momentumScores)
+          .where(eq(momentumScores.toolId, tool.id))
+          .orderBy(desc(momentumScores.calculatedAt))
+          .limit(1);
+
+        const [gh] = await db
+          .select()
+          .from(githubSnapshots)
+          .where(eq(githubSnapshots.toolId, tool.id))
+          .orderBy(desc(githubSnapshots.collectedAt))
+          .limit(1);
+
+        return {
+          name: tool.name,
+          category: tool.category,
+          description: tool.description,
+          repo: tool.repo,
+          stars: gh?.stars ?? 0,
+          starVelocity: score?.starVelocity ?? 0,
+          overallScore: score?.overallScore ?? 0,
+        };
+      })
+    );
+
+    const leaderboardContext = toolsWithScores
+      .sort((a, b) => b.overallScore - a.overallScore)
+      .map(
+        (t) =>
+          `- ${t.name} (${t.category}): ${t.stars.toLocaleString()} stars, velocity=${t.starVelocity}/day, momentum=${t.overallScore.toFixed(1)} — ${t.description}`
+      )
+      .join("\n");
+
+    const response = await anthropic.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 4096,
+      tools: [ANALYSIS_TOOL],
+      tool_choice: { type: "tool", name: "analyze_stack" },
+      messages: [
+        {
+          role: "user",
+          content: `You are an AI stack health advisor. Analyze the following repository's dependencies against our live momentum leaderboard data.
+
+Repository: ${parsed.owner}/${parsed.repo}
+
+Detected dependencies:
+${allDeps.join(", ")}
+
+Momentum leaderboard (all tracked tools, sorted by score):
+${leaderboardContext}
+
+Instructions:
+1. Identify which dependencies correspond to tools on our leaderboard (match by name, npm package name, or GitHub repo name)
+2. For tracked tools, classify as "accelerating" (high velocity), "stable" (moderate), or "stagnating" (low/negative)
+3. For important tools NOT on our leaderboard, still include them with a momentum score of 0 and a note
+4. Suggest upgrades where a higher-momentum alternative exists in the same category
+5. Calculate an overall health score (0-100) based on the weighted momentum of detected tools
+6. Generate a Mermaid.js flowchart TD diagram showing the current architecture with tools color-coded:
+   - Green (classDef accelerating) for accelerating tools
+   - Yellow (classDef stable) for stable tools
+   - Red (classDef stagnating) for stagnating tools
+
+Mermaid syntax rules:
+- Quote all node labels with special characters
+- No classDef in subgraph declarations
+- No spaces in pipe characters for edge labels
+- No subgraph aliases
+- No %%{init}%% directives`,
+        },
+      ],
+    });
+
+    const toolUseBlock = response.content.find(
+      (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
+    );
+
+    if (!toolUseBlock) {
+      return NextResponse.json(
+        { error: "Failed to analyze repository" },
+        { status: 500 }
+      );
+    }
+
+    const result = toolUseBlock.input as Record<string, unknown>;
+
+    // Validate and repair diagram
+    let diagram = stripMermaidCodeFences(String(result.diagram ?? ""));
+    const validation = await validateMermaidSyntax(diagram);
+    if (!validation.valid) {
+      const fixResponse = await anthropic.messages.create({
+        model: "claude-sonnet-4-20250514",
+        max_tokens: 2048,
+        messages: [
+          {
+            role: "user",
+            content: `Fix this Mermaid.js diagram syntax error. Return ONLY the corrected Mermaid code — no explanation, no markdown fences.
+
+Broken diagram:
+${diagram}
+
+Parser error:
+${validation.error}
+
+Rules: Quote node labels with special characters. No classDef in subgraph declarations. No spaces inside pipe characters. No subgraph aliases. No %%{init}%% directives.`,
+          },
+        ],
+      });
+      const fixedText = fixResponse.content
+        .filter((b): b is Anthropic.TextBlock => b.type === "text")
+        .map((b) => b.text)
+        .join("");
+      diagram = stripMermaidCodeFences(fixedText);
+    }
+    result.diagram = diagram;
+
+    return NextResponse.json({ result });
+  } catch (error) {
+    console.error("Analyze repo error:", error);
+    return NextResponse.json(
+      { error: "Failed to analyze repository" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -8,6 +8,7 @@ import { Menu, X, Github } from "lucide-react";
 const NAV_LINKS = [
   { href: "/leaderboard", label: "Leaderboard" },
   { href: "/generate", label: "Generate Stack" },
+  { href: "/analyze", label: "Stack Health" },
 ];
 
 export function NavBar() {

--- a/src/components/repo-analyzer.tsx
+++ b/src/components/repo-analyzer.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ArrowRight,
+  Loader2,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Github,
+  Lightbulb,
+} from "lucide-react";
+import { MermaidDiagram } from "@/components/mermaid-diagram";
+
+interface DetectedTool {
+  name: string;
+  category: string;
+  status: "accelerating" | "stable" | "stagnating";
+  momentumScore: number;
+  note: string;
+}
+
+interface Suggestion {
+  current: string;
+  suggested: string;
+  reason: string;
+}
+
+interface RepoAnalysis {
+  summary: string;
+  overallHealthScore: number;
+  detectedTools: DetectedTool[];
+  suggestions: Suggestion[];
+  diagram: string;
+}
+
+function scoreColor(score: number): string {
+  if (score >= 70) return "text-emerald-400";
+  if (score >= 40) return "text-amber-400";
+  return "text-red-400";
+}
+
+function scoreBg(score: number): string {
+  if (score >= 70) return "bg-emerald-950/50 border-emerald-900/50";
+  if (score >= 40) return "bg-amber-950/50 border-amber-900/50";
+  return "bg-red-950/50 border-red-900/50";
+}
+
+function StatusIcon({ status }: { status: DetectedTool["status"] }) {
+  switch (status) {
+    case "accelerating":
+      return <TrendingUp className="w-4 h-4 text-emerald-400" />;
+    case "stable":
+      return <Minus className="w-4 h-4 text-zinc-400" />;
+    case "stagnating":
+      return <TrendingDown className="w-4 h-4 text-red-400" />;
+  }
+}
+
+function statusLabel(status: DetectedTool["status"]): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function statusColor(status: DetectedTool["status"]): string {
+  switch (status) {
+    case "accelerating":
+      return "text-emerald-400";
+    case "stable":
+      return "text-zinc-400";
+    case "stagnating":
+      return "text-red-400";
+  }
+}
+
+export function RepoAnalyzer() {
+  const [repoUrl, setRepoUrl] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<RepoAnalysis | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleAnalyze() {
+    if (!repoUrl.trim()) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const res = await fetch("/api/analyze-repo", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repoUrl: repoUrl.trim() }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error ?? "Failed to analyze repository");
+      }
+      setResult(data.result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div>
+      {/* URL Input */}
+      <div className="flex gap-3">
+        <div className="relative flex-1">
+          <div className="absolute left-4 top-1/2 -translate-y-1/2">
+            <Github className="w-5 h-5 text-zinc-500" />
+          </div>
+          <input
+            type="url"
+            value={repoUrl}
+            onChange={(e) => setRepoUrl(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAnalyze()}
+            placeholder="https://github.com/owner/repo"
+            className="w-full bg-zinc-900 border border-zinc-800 rounded-xl pl-12 pr-4 py-3 text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:border-zinc-600 transition-colors"
+            disabled={loading}
+          />
+        </div>
+        <button
+          onClick={handleAnalyze}
+          disabled={loading || !repoUrl.trim()}
+          className="px-6 py-3 bg-white text-zinc-900 rounded-xl font-medium hover:bg-zinc-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 shrink-0"
+        >
+          {loading ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Analyzing...
+            </>
+          ) : (
+            <>
+              Analyze
+              <ArrowRight className="w-4 h-4" />
+            </>
+          )}
+        </button>
+      </div>
+
+      {error && (
+        <div className="mt-6 p-4 bg-red-950/50 border border-red-900 rounded-xl text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+
+      {loading && (
+        <div className="mt-8 p-6 border border-zinc-800 rounded-xl bg-zinc-900/30 flex items-center gap-3">
+          <Loader2 className="w-5 h-5 animate-spin text-zinc-400" />
+          <span className="text-zinc-400">
+            Fetching dependencies and analyzing against momentum data...
+          </span>
+        </div>
+      )}
+
+      {result && (
+        <div className="mt-8 space-y-8">
+          {/* Health Score */}
+          <div
+            className={`p-6 rounded-xl border ${scoreBg(result.overallHealthScore)}`}
+          >
+            <div className="flex items-center gap-5">
+              <div
+                className={`text-5xl font-bold ${scoreColor(result.overallHealthScore)}`}
+              >
+                {result.overallHealthScore}
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold">Stack Health Score</h2>
+                <p className="text-zinc-400 text-sm mt-1 leading-relaxed">
+                  {result.summary}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Detected Tools */}
+          <div>
+            <h2 className="text-lg font-semibold mb-4">Detected Tools</h2>
+            <div className="grid gap-3">
+              {result.detectedTools.map((tool, i) => (
+                <div
+                  key={i}
+                  className="flex items-center justify-between p-4 border border-zinc-800 rounded-xl bg-zinc-900/30"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3 mb-1">
+                      <span className="font-medium text-zinc-100">
+                        {tool.name}
+                      </span>
+                      <span className="text-xs px-2 py-0.5 rounded-md bg-zinc-800 text-zinc-400">
+                        {tool.category}
+                      </span>
+                    </div>
+                    <p className="text-sm text-zinc-500 truncate">{tool.note}</p>
+                  </div>
+                  <div className="flex items-center gap-3 ml-4 shrink-0">
+                    <StatusIcon status={tool.status} />
+                    <span
+                      className={`text-sm font-medium ${statusColor(tool.status)}`}
+                    >
+                      {statusLabel(tool.status)}
+                    </span>
+                    {tool.momentumScore > 0 && (
+                      <span className="text-xs text-zinc-500">
+                        {tool.momentumScore.toFixed(1)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Upgrade Suggestions */}
+          {result.suggestions.length > 0 && (
+            <div>
+              <div className="flex items-center gap-2 mb-4">
+                <Lightbulb className="w-4 h-4 text-amber-400" />
+                <h2 className="text-lg font-semibold">Upgrade Suggestions</h2>
+              </div>
+              <div className="grid gap-3">
+                {result.suggestions.map((suggestion, i) => (
+                  <div
+                    key={i}
+                    className="p-4 border border-amber-900/30 bg-amber-950/20 rounded-xl"
+                  >
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className="text-zinc-400">{suggestion.current}</span>
+                      <ArrowRight className="w-3.5 h-3.5 text-amber-400" />
+                      <span className="font-medium text-zinc-100">
+                        {suggestion.suggested}
+                      </span>
+                    </div>
+                    <p className="text-sm text-zinc-500 leading-relaxed">
+                      {suggestion.reason}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Architecture Diagram */}
+          {result.diagram && (
+            <div>
+              <h2 className="text-lg font-semibold mb-4">
+                Architecture Overview
+              </h2>
+              <MermaidDiagram chart={result.diagram} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
New **Stack Health Check** feature at `/analyze`:
- Paste a GitHub repo URL → fetches `package.json`, `requirements.txt`, and `pyproject.toml` via GitHub API
- Extracts dependencies and cross-references against our momentum leaderboard
- Uses Claude (tool_use) to generate a structured health report:
  - **Health score** (0-100) with color-coded badge
  - **Detected tools** grid with momentum status indicators (accelerating ↑, stable —, stagnating ↓)
  - **Upgrade suggestions** with reasoning based on momentum data
  - **Architecture diagram** color-coded by tool momentum (green/yellow/red)
- Includes Mermaid validation + repair for the generated diagram
- Added "Stack Health" to the navbar

## New files
- `src/app/api/analyze-repo/route.ts` — API endpoint (GitHub API + dependency parsing + Claude analysis)
- `src/app/analyze/page.tsx` — Page wrapper
- `src/components/repo-analyzer.tsx` — Client component with URL input and results rendering

## Inspiration
Inspired by [gitdiagram](https://github.com/ahmedkhaleel2004/gitdiagram)'s repo-URL-driven analysis concept, but with a unique focus on momentum-based stack health instead of architecture diagrams.

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Paste `https://github.com/vercel/next.js` — detects Next.js, React, etc.
- [ ] Paste a Python project — detects Python deps from requirements.txt
- [ ] Invalid URL shows error message
- [ ] Non-existent repo shows error message
- [ ] Navbar shows "Stack Health" link and highlights when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)