### PR TITLE
Add test suite, CI workflow, and scoring module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,74 @@
+# Launch Readiness Plan
+
+## Feedback Triage
+
+### Signal (worth doing)
+
+| # | Item | Why it matters | Effort |
+|---|------|---------------|--------|
+| **P0-1** | Missing OSS files (LICENSE, CONTRIBUTING, etc.) | No license = legally unusable. 10min to add MIT + boilerplate. | Trivial |
+| **P0-2** | Rate limiting on `/api/generate` | Real risk — one curl loop drains your Anthropic budget. | Medium |
+| **P0-4** | Secret naming (GH_PAT vs GITHUB_TOKEN in docs) | Confirmed: workflow maps `secrets.GH_PAT` → env `GITHUB_TOKEN`. Docs say `GITHUB_TOKEN`. Not broken, but the `.env.example` should mention `GH_PAT` is the Actions secret name. | Trivial |
+| **P1-1** | Tool seeding doesn't sync updates | Real issue: after first run, editing `tools.json` does nothing. Need upsert. | Medium |
+| **P1-2** | N+1 query pattern (3 locations) | 121 DB queries per page load with 60 tools. Will get worse as tools grow. This is the biggest perf win available. | Medium |
+| **P1-3** | Hardcoded production URL | Blocks self-hosters. Use `NEXT_PUBLIC_APP_URL` or relative URLs. | Trivial |
+| **P1-4** | Silent failure paths | Home/leaderboard return empty arrays on DB error with no logging. At minimum add `console.error`. | Trivial |
+| **P1-5** | No CI for PRs | Only scheduled workflow exists. Need lint/test/build on PR. | Small |
+| **P1-6** | Dependency vulns | 4 moderate via drizzle-kit/esbuild — dev deps only, low real risk. Worth noting but not blocking. | Trivial |
+
+### Noise (skip or defer indefinitely)
+
+| # | Item | Why it's noise |
+|---|------|---------------|
+| **P0-3** | Share endpoint retention policy / privacy compliance | You're storing a prompt + generated output with a random ID. There's no PII collection, no auth, no user accounts. This is the same as any pastebin. If this becomes a real product with users, revisit. For launch? Non-issue. |
+| **P2-1** | Methodology page | Nice-to-have product feature, not launch-blocking. The scoring is in the README already. |
+| **P2-2** | Historical trend UX / sparklines | Product roadmap item. Not a fix. |
+| **P2-3** | HN scoring noise | Theoretical concern. You'd need evidence of actual false positives before optimizing. |
+| **P2-4** | Unused `/api/leaderboard` endpoint | It's a few lines of code. Keep it — it's a useful public API for others to consume. Removing it saves nothing. |
+| **Abuse protection on `/api/share`** | It's a write of ~2KB to Postgres. Not an expensive operation. Rate limiting `/api/generate` (the Anthropic call) is what matters. |
+| **CONTRIBUTING / CODE_OF_CONDUCT** | For a solo project, a LICENSE is essential. The rest is ceremony — add them when you actually want contributors. |
+
+### Testing strategy (since you're solo + vibecoding)
+
+The feedback says "add tests" but doesn't say *what* to test. For a solo developer, the highest-value tests are:
+
+1. **API route tests** — mock the DB, test that `/api/generate` validates input, streams correctly, handles errors. Mock Anthropic SDK. These catch regressions when you refactor.
+2. **Data collection script tests** — test the scoring math, upsert logic, edge cases (first run vs subsequent). These are pure functions, easy to test.
+3. **Query helper tests** — once you fix N+1, test the new joined query returns correct shape.
+4. **Skip UI component tests for now** — Vitest + React Testing Library for components is high effort, low value at this stage. Visual verification via preview tools is faster.
+
+---
+
+## Execution Plan
+
+### Phase 1: Foundations (testing + CI)
+*Do this first so everything after is verified.*
+
+1. **Add CI workflow** — `.github/workflows/ci.yml` running `lint`, `test`, `build` on PR
+2. **Add API route tests** — test input validation, error responses, SSE stream format for `/api/generate` and `/api/share`
+3. **Add scoring logic tests** — extract scoring math from collect scripts into testable pure functions, write unit tests
+4. **Add query tests** — will be written alongside the N+1 fix in Phase 2
+
+### Phase 2: Fix real bugs
+*Highest-impact code changes.*
+
+5. **Fix N+1 queries** — replace per-tool subqueries with proper SQL joins in all 4 locations (home, leaderboard, `/api/generate`, `/api/leaderboard`). Write tests for the new query helpers.
+6. **Fix tool seeding to upsert** — change `collect-github.ts` seeding to insert new tools, update changed metadata, handle removed tools. Add test.
+7. **Add rate limiting to `/api/generate`** — IP-based rate limit (e.g., 10 requests/hour). Use in-memory store for simplicity (no Redis needed at this scale). Consider Vercel's built-in rate limiting if deployed there.
+8. **Add error logging** — replace silent catch blocks with `console.error` in home + leaderboard pages.
+
+### Phase 3: Launch hygiene
+*Quick wins, do right before posting.*
+
+9. **Add MIT LICENSE** file
+10. **Fix hardcoded URLs** — use env var or `headers().get('host')` for share URLs
+11. **Update `.env.example`** — clarify that `GH_PAT` is the GitHub Actions secret name
+12. **Run `npm audit` and document** — note that vulns are in dev deps only
+
+### Not doing (and why)
+- **Share retention/privacy policy** — premature for launch scope
+- **Methodology page** — product feature, not launch-blocking
+- **Sparklines/trend charts** — roadmap, not fix
+- **HN scoring refinement** — no evidence of actual problem
+- **CONTRIBUTING/CODE_OF_CONDUCT** — add when seeking contributors
+- **Dependabot/CodeQL** — overkill for solo project, CI lint/test/build is sufficient

--- a/scripts/collect-github.ts
+++ b/scripts/collect-github.ts
@@ -3,6 +3,11 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import { eq, desc } from "drizzle-orm";
 import { tools, githubSnapshots, momentumScores } from "../src/lib/schema";
 import toolsData from "../src/data/tools.json";
+import {
+  calculateStarVelocity,
+  estimateInitialVelocity,
+  roundScore,
+} from "../src/lib/scoring";
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
@@ -117,37 +122,27 @@ async function calculateMomentumScores() {
     let starVelocity = 0;
 
     if (snapshots.length === 2) {
-      // snapshots[0] = newest, snapshots[1] = older (desc order)
       const newer = snapshots[0];
       const older = snapshots[1];
       const timeDiffMs =
         new Date(newer.collectedAt).getTime() - new Date(older.collectedAt).getTime();
-      const timeDiffDays = timeDiffMs / (1000 * 60 * 60 * 24);
-      if (timeDiffDays > 0) {
-        starVelocity = (newer.stars - older.stars) / timeDiffDays;
-      }
+      starVelocity = calculateStarVelocity(newer.stars, older.stars, timeDiffMs);
     }
 
-    // For first run, estimate velocity from total stars / repo age
-    // This gives a baseline that gets refined with daily collection
     if (snapshots.length === 1) {
-      // Use a rough estimate: assume repo is ~2 years old on average
-      starVelocity = snapshots[0].stars / 730;
+      starVelocity = estimateInitialVelocity(snapshots[0].stars);
     }
 
-    // Overall score = weighted composite
-    // Star velocity is the primary signal for now
-    // HN data gets factored in by the HN collector
     const overallScore = starVelocity;
 
     await db.insert(momentumScores).values({
       toolId: tool.id,
-      starVelocity: Math.round(starVelocity * 100) / 100,
+      starVelocity: roundScore(starVelocity),
       hnMentions7d: 0,
       hnPoints7d: 0,
       npmDownloads7d: 0,
       pypiDownloads7d: 0,
-      overallScore: Math.round(overallScore * 100) / 100,
+      overallScore: roundScore(overallScore),
     });
 
     console.log(

--- a/scripts/collect-hn.ts
+++ b/scripts/collect-hn.ts
@@ -2,6 +2,7 @@ import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { eq, and, gte, desc } from "drizzle-orm";
 import { tools, hnSnapshots, momentumScores } from "../src/lib/schema";
+import { calculateHNBoost, calculateOverallScore, roundScore } from "../src/lib/scoring";
 
 const DATABASE_URL = process.env.DATABASE_URL;
 
@@ -133,10 +134,8 @@ async function updateMomentumWithHN() {
 
     if (!latestMomentum) continue;
 
-    // Update the momentum score with HN data
-    // Scoring: star_velocity + (hn_points_7d * 0.1) + (hn_mentions_7d * 2)
-    const hnBoost = latestHN.totalPoints * 0.1 + latestHN.mentionCount * 2;
-    const overallScore = latestMomentum.starVelocity + hnBoost;
+    const hnBoost = calculateHNBoost(latestHN.totalPoints, latestHN.mentionCount);
+    const overallScore = calculateOverallScore(latestMomentum.starVelocity, hnBoost);
 
     await db.insert(momentumScores).values({
       toolId: tool.id,
@@ -145,7 +144,7 @@ async function updateMomentumWithHN() {
       hnPoints7d: latestHN.totalPoints,
       npmDownloads7d: 0,
       pypiDownloads7d: 0,
-      overallScore: Math.round(overallScore * 100) / 100,
+      overallScore: roundScore(overallScore),
     });
 
     if (hnBoost > 0) {

--- a/src/app/api/generate/__tests__/route.test.ts
+++ b/src/app/api/generate/__tests__/route.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock db before importing route
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+// Mock mermaid validation (uses dynamic import which is problematic in tests)
+vi.mock("@/lib/mermaid-validate", () => ({
+  validateMermaidSyntax: vi.fn().mockResolvedValue({ valid: true }),
+  stripMermaidCodeFences: vi.fn((text: string) => text),
+}));
+
+// Mock Anthropic SDK — must be a class since route does `new Anthropic()`
+// Use vi.hoisted so the variable is available inside the vi.mock factory
+const { mockCreate } = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+}));
+vi.mock("@anthropic-ai/sdk", () => {
+  return {
+    default: class MockAnthropic {
+      messages = { create: mockCreate };
+    },
+  };
+});
+
+import { POST } from "../route";
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3001/api/generate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function readStream(res: Response): Promise<string> {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value);
+  }
+  return text;
+}
+
+describe("POST /api/generate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when prompt is missing", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid prompt");
+  });
+
+  it("returns 400 when prompt is not a string", async () => {
+    const res = await POST(makeRequest({ prompt: 123 }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid prompt");
+  });
+
+  it("returns 400 when prompt exceeds 2000 characters", async () => {
+    const res = await POST(makeRequest({ prompt: "a".repeat(2001) }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid prompt");
+  });
+
+  it("returns 400 for empty string prompt", async () => {
+    const res = await POST(makeRequest({ prompt: "" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid prompt");
+  });
+
+  it("accepts valid prompt and returns SSE stream", async () => {
+    // Mock db to return empty tools list
+    const { db } = await import("@/lib/db");
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockResolvedValue([]),
+    } as never);
+
+    // Mock Anthropic responses
+    mockCreate
+      // Stage 1: tool selection
+      .mockResolvedValueOnce({
+        content: [
+          {
+            type: "tool_use",
+            name: "describe_architecture",
+            input: {
+              summary: "Test summary",
+              tools: [{ name: "TestTool", category: "test", reason: "testing" }],
+              diagramDescription: "A simple diagram",
+              buildSteps: ["Step 1"],
+              tradeoffs: ["Tradeoff 1"],
+            },
+          },
+        ],
+      })
+      // Stage 2: diagram generation
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "graph TD\n  A-->B" }],
+      });
+
+    const res = await POST(makeRequest({ prompt: "Build a chatbot" }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+    expect(res.headers.get("Cache-Control")).toBe("no-cache");
+
+    const fullText = await readStream(res);
+    expect(fullText).toContain("data:");
+    expect(fullText).toContain('"status":"complete"');
+    expect(fullText).toContain("Test summary");
+  });
+
+  it("streams error when Anthropic returns no tool_use block", async () => {
+    const { db } = await import("@/lib/db");
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockResolvedValue([]),
+    } as never);
+
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "I cannot help with that" }],
+    });
+
+    const res = await POST(makeRequest({ prompt: "Build something" }));
+    const fullText = await readStream(res);
+    expect(fullText).toContain('"status":"error"');
+  });
+
+  it("streams error when DB query fails", async () => {
+    const { db } = await import("@/lib/db");
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockRejectedValue(new Error("DB connection failed")),
+    } as never);
+
+    const res = await POST(makeRequest({ prompt: "Build a chatbot" }));
+    const fullText = await readStream(res);
+    expect(fullText).toContain('"status":"error"');
+  });
+});

--- a/src/app/api/leaderboard/__tests__/route.test.ts
+++ b/src/app/api/leaderboard/__tests__/route.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { tools as toolsTable, momentumScores } from "@/lib/schema";
+
+const mockToolRows = [
+  { id: 1, name: "ToolA", repo: "org/tool-a", category: "llm", description: "LLM tool", website: "https://a.com", hnSearchTerms: [], npmPackage: null, pypiPackage: null, createdAt: new Date() },
+  { id: 2, name: "ToolB", repo: "org/tool-b", category: "vector-db", description: "Vector DB", website: "https://b.com", hnSearchTerms: [], npmPackage: null, pypiPackage: null, createdAt: new Date() },
+];
+
+const mockScoreRows: Record<number, unknown> = {
+  1: { starVelocity: 50, hnMentions7d: 3, hnPoints7d: 100, overallScore: 60, calculatedAt: new Date() },
+  2: { starVelocity: 100, hnMentions7d: 5, hnPoints7d: 200, overallScore: 120, calculatedAt: new Date() },
+};
+
+const mockGHRows: Record<number, unknown> = {
+  1: { stars: 10000, forks: 500 },
+  2: { stars: 50000, forks: 2000 },
+};
+
+// Use vi.hoisted for the toolId tracker (available in vi.mock factory)
+const { lastWhereToolId } = vi.hoisted(() => ({
+  lastWhereToolId: { value: 0 },
+}));
+
+// Mock db using referential equality on the actual schema table objects
+// to determine which table is being queried
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: (table: unknown) => {
+        // tools table: return all tools directly
+        if (table === toolsTable) {
+          return Promise.resolve(mockToolRows);
+        }
+
+        // momentum_scores or github_snapshots: return chainable
+        const isScoreTable = table === momentumScores;
+        return {
+          where: () => {
+            // Extract toolId from the eq() condition
+            // The condition is a drizzle BinaryOperator but we can
+            // inspect it via the mock's call — use a simpler approach:
+            // the where() receives eq(column, value) which internally
+            // stores the value. Since we can't easily extract it,
+            // we track which tool is being queried by looking at the
+            // condition's right-hand value.
+            //
+            // Simpler: drizzle eq() produces an object with .value
+            // Let's just extract it from the SQL representation.
+            // Actually simplest: since tools are queried in order via
+            // Promise.all on allTools.map(), and within each map callback
+            // the score query runs before the GH query (they await sequentially),
+            // we can track by the score query setting the current toolId.
+            if (isScoreTable) {
+              // Score queries come first for each tool — cycle through tools
+              const nextToolIdx = Object.values(mockScoreRows).length > 0
+                ? (lastWhereToolId.value < mockToolRows.length ? lastWhereToolId.value : 0)
+                : 0;
+              lastWhereToolId.value = nextToolIdx + 1;
+            }
+            return {
+              orderBy: () => ({
+                limit: () => {
+                  // Determine toolId based on table type
+                  // Score query: use the incremented index
+                  // GH query: use same toolId (runs right after score for same tool)
+                  const toolId = isScoreTable
+                    ? mockToolRows[lastWhereToolId.value - 1]?.id ?? 1
+                    : mockToolRows[lastWhereToolId.value - 1]?.id ?? 1;
+
+                  if (isScoreTable) {
+                    return Promise.resolve(mockScoreRows[toolId] ? [mockScoreRows[toolId]] : []);
+                  }
+                  return Promise.resolve(mockGHRows[toolId] ? [mockGHRows[toolId]] : []);
+                },
+              }),
+            };
+          },
+        };
+      },
+    }),
+  },
+}));
+
+import { GET } from "../route";
+
+function makeGetRequest(params?: Record<string, string>): NextRequest {
+  const url = new URL("http://localhost:3001/api/leaderboard");
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  }
+  return new NextRequest(url);
+}
+
+describe("GET /api/leaderboard", () => {
+  beforeEach(() => {
+    lastWhereToolId.value = 0;
+  });
+
+  it("returns sorted leaderboard data", async () => {
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.tools).toBeDefined();
+    expect(Array.isArray(data.tools)).toBe(true);
+    expect(data.tools.length).toBe(2);
+    // Should be sorted by overallScore descending (ToolB: 120 > ToolA: 60)
+    expect(data.tools[0].name).toBe("ToolB");
+    expect(data.tools[1].name).toBe("ToolA");
+  });
+
+  it("includes expected fields in response", async () => {
+    const res = await GET(makeGetRequest());
+    const data = await res.json();
+    const tool = data.tools[0];
+    expect(tool).toHaveProperty("id");
+    expect(tool).toHaveProperty("name");
+    expect(tool).toHaveProperty("repo");
+    expect(tool).toHaveProperty("category");
+    expect(tool).toHaveProperty("stars");
+    expect(tool).toHaveProperty("forks");
+    expect(tool).toHaveProperty("starVelocity");
+    expect(tool).toHaveProperty("overallScore");
+  });
+
+  it("returns numeric values for scores and stars", async () => {
+    const res = await GET(makeGetRequest());
+    const data = await res.json();
+    for (const tool of data.tools) {
+      expect(typeof tool.stars).toBe("number");
+      expect(typeof tool.overallScore).toBe("number");
+      expect(typeof tool.starVelocity).toBe("number");
+      expect(tool.overallScore).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/app/api/share/__tests__/route.test.ts
+++ b/src/app/api/share/__tests__/route.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock db
+const mockInsert = vi.fn();
+const mockSelect = vi.fn();
+vi.mock("@/lib/db", () => ({
+  db: {
+    insert: (...args: unknown[]) => mockInsert(...args),
+    select: (...args: unknown[]) => mockSelect(...args),
+  },
+}));
+
+// Mock nanoid
+vi.mock("nanoid", () => ({
+  nanoid: vi.fn(() => "abc1234567"),
+}));
+
+import { POST, GET } from "../route";
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3001/api/share", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGetRequest(params?: Record<string, string>): NextRequest {
+  const url = new URL("http://localhost:3001/api/share");
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  }
+  return new NextRequest(url);
+}
+
+describe("POST /api/share", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when prompt is missing", async () => {
+    const res = await POST(makePostRequest({ result: {} }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid data");
+  });
+
+  it("returns 400 when result is missing", async () => {
+    const res = await POST(makePostRequest({ prompt: "test" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid data");
+  });
+
+  it("returns 400 when body is empty", async () => {
+    const res = await POST(makePostRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("saves and returns share URL on valid input", async () => {
+    mockInsert.mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const res = await POST(
+      makePostRequest({
+        prompt: "Build a chatbot",
+        result: { summary: "test", tools: [] },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.id).toBe("abc1234567");
+    expect(data.url).toBe("/stack/abc1234567");
+  });
+
+  it("returns 500 when DB insert fails", async () => {
+    mockInsert.mockReturnValue({
+      values: vi.fn().mockRejectedValue(new Error("DB error")),
+    });
+
+    const res = await POST(
+      makePostRequest({
+        prompt: "test",
+        result: { summary: "test" },
+      })
+    );
+
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe("Failed to save stack");
+  });
+});
+
+describe("GET /api/share", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when id param is missing", async () => {
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("ID required");
+  });
+
+  it("returns 404 when stack is not found", async () => {
+    const mockChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+    };
+    mockSelect.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest({ id: "nonexistent" }));
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBe("Stack not found");
+  });
+
+  it("returns stack data when found", async () => {
+    const stackData = {
+      id: "abc1234567",
+      prompt: "Build a chatbot",
+      result: { summary: "test" },
+      createdAt: new Date().toISOString(),
+    };
+    const mockChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([stackData]),
+    };
+    mockSelect.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest({ id: "abc1234567" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.id).toBe("abc1234567");
+    expect(data.prompt).toBe("Build a chatbot");
+  });
+
+  it("returns 500 when DB query fails", async () => {
+    const mockChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockRejectedValue(new Error("DB error")),
+    };
+    mockSelect.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest({ id: "abc1234567" }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe("Failed to fetch stack");
+  });
+});

--- a/src/lib/__tests__/mermaid-validate.test.ts
+++ b/src/lib/__tests__/mermaid-validate.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { stripMermaidCodeFences } from "@/lib/mermaid-validate";
+
+describe("stripMermaidCodeFences", () => {
+  it("strips opening and closing fences", () => {
+    const input = "```mermaid\ngraph TD\n  A-->B\n```";
+    expect(stripMermaidCodeFences(input)).toBe("graph TD\n  A-->B");
+  });
+
+  it("handles case-insensitive mermaid tag", () => {
+    const input = "```Mermaid\ngraph TD\n```";
+    expect(stripMermaidCodeFences(input)).toBe("graph TD");
+  });
+
+  it("returns trimmed input when no fences present", () => {
+    const input = "  graph TD\n  A-->B  ";
+    expect(stripMermaidCodeFences(input)).toBe("graph TD\n  A-->B");
+  });
+
+  it("handles empty string", () => {
+    expect(stripMermaidCodeFences("")).toBe("");
+  });
+
+  it("handles fences with extra whitespace", () => {
+    const input = "```mermaid  \ngraph TD\n```  ";
+    expect(stripMermaidCodeFences(input)).toBe("graph TD");
+  });
+
+  it("only strips fences at start and end, not in the middle", () => {
+    const input = "```mermaid\ngraph TD\nA[\"```test```\"]\n```";
+    const result = stripMermaidCodeFences(input);
+    expect(result).toContain('A["```test```"]');
+  });
+});

--- a/src/lib/__tests__/scoring.test.ts
+++ b/src/lib/__tests__/scoring.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateStarVelocity,
+  estimateInitialVelocity,
+  calculateHNBoost,
+  calculateOverallScore,
+  roundScore,
+} from "@/lib/scoring";
+
+describe("calculateStarVelocity", () => {
+  it("calculates stars gained per day", () => {
+    const oneDay = 1000 * 60 * 60 * 24;
+    expect(calculateStarVelocity(1100, 1000, oneDay)).toBe(100);
+  });
+
+  it("handles multi-day periods", () => {
+    const sevenDays = 7 * 1000 * 60 * 60 * 24;
+    expect(calculateStarVelocity(1070, 1000, sevenDays)).toBe(10);
+  });
+
+  it("returns 0 for zero time difference", () => {
+    expect(calculateStarVelocity(1100, 1000, 0)).toBe(0);
+  });
+
+  it("returns 0 for negative time difference", () => {
+    expect(calculateStarVelocity(1100, 1000, -1000)).toBe(0);
+  });
+
+  it("handles star decrease (negative velocity)", () => {
+    const oneDay = 1000 * 60 * 60 * 24;
+    expect(calculateStarVelocity(900, 1000, oneDay)).toBe(-100);
+  });
+
+  it("handles no change in stars", () => {
+    const oneDay = 1000 * 60 * 60 * 24;
+    expect(calculateStarVelocity(1000, 1000, oneDay)).toBe(0);
+  });
+});
+
+describe("estimateInitialVelocity", () => {
+  it("estimates velocity assuming ~2yr repo age", () => {
+    expect(estimateInitialVelocity(73000)).toBeCloseTo(100, 0);
+  });
+
+  it("returns 0 for 0 stars", () => {
+    expect(estimateInitialVelocity(0)).toBe(0);
+  });
+
+  it("handles small star counts", () => {
+    const result = estimateInitialVelocity(730);
+    expect(result).toBe(1);
+  });
+});
+
+describe("calculateHNBoost", () => {
+  it("applies the scoring formula: points * 0.1 + mentions * 2", () => {
+    // 100 points * 0.1 = 10, 5 mentions * 2 = 10, total = 20
+    expect(calculateHNBoost(100, 5)).toBe(20);
+  });
+
+  it("returns 0 for no HN activity", () => {
+    expect(calculateHNBoost(0, 0)).toBe(0);
+  });
+
+  it("weights points at 0.1x", () => {
+    expect(calculateHNBoost(1000, 0)).toBe(100);
+  });
+
+  it("weights mentions at 2x", () => {
+    expect(calculateHNBoost(0, 10)).toBe(20);
+  });
+});
+
+describe("calculateOverallScore", () => {
+  it("sums star velocity and HN boost", () => {
+    expect(calculateOverallScore(50, 20)).toBe(70);
+  });
+
+  it("works with zero HN boost", () => {
+    expect(calculateOverallScore(50, 0)).toBe(50);
+  });
+
+  it("works with zero velocity", () => {
+    expect(calculateOverallScore(0, 20)).toBe(20);
+  });
+});
+
+describe("roundScore", () => {
+  it("rounds to 2 decimal places", () => {
+    expect(roundScore(10.456)).toBe(10.46);
+  });
+
+  it("preserves exact values", () => {
+    expect(roundScore(10.5)).toBe(10.5);
+  });
+
+  it("handles 0", () => {
+    expect(roundScore(0)).toBe(0);
+  });
+});

--- a/src/lib/__tests__/sse.test.ts
+++ b/src/lib/__tests__/sse.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { sseMessage, parseSSEBuffer } from "@/lib/sse";
+
+describe("sseMessage", () => {
+  it("formats a payload as an SSE data line", () => {
+    const result = sseMessage({ status: "started" });
+    expect(result).toBe('data: {"status":"started"}\n\n');
+  });
+
+  it("serializes nested objects", () => {
+    const result = sseMessage({
+      status: "complete",
+      result: { summary: "test", tools: [] },
+    });
+    const parsed = JSON.parse(result.replace("data: ", "").trim());
+    expect(parsed.status).toBe("complete");
+    expect(parsed.result.summary).toBe("test");
+  });
+});
+
+describe("parseSSEBuffer", () => {
+  it("parses a single complete message", () => {
+    const buffer = 'data: {"status":"started"}\n\n';
+    const { messages, remainder } = parseSSEBuffer(buffer);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].status).toBe("started");
+    expect(remainder).toBe("");
+  });
+
+  it("parses multiple complete messages", () => {
+    const buffer =
+      'data: {"status":"started"}\n\n' +
+      'data: {"status":"selecting_tools"}\n\n';
+    const { messages, remainder } = parseSSEBuffer(buffer);
+    expect(messages).toHaveLength(2);
+    expect(messages[0].status).toBe("started");
+    expect(messages[1].status).toBe("selecting_tools");
+    expect(remainder).toBe("");
+  });
+
+  it("keeps incomplete messages as remainder", () => {
+    const buffer = 'data: {"status":"started"}\n\ndata: {"status":';
+    const { messages, remainder } = parseSSEBuffer(buffer);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].status).toBe("started");
+    expect(remainder).toBe('data: {"status":');
+  });
+
+  it("returns empty messages for empty buffer", () => {
+    const { messages, remainder } = parseSSEBuffer("");
+    expect(messages).toHaveLength(0);
+    expect(remainder).toBe("");
+  });
+
+  it("skips malformed JSON gracefully", () => {
+    const buffer = "data: {broken json}\n\ndata: {\"status\":\"ok\"}\n\n";
+    const { messages } = parseSSEBuffer(buffer);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].status).toBe("ok");
+  });
+
+  it("ignores lines that don't start with data:", () => {
+    const buffer = "event: ping\ndata: {\"status\":\"ok\"}\n\n";
+    const { messages } = parseSSEBuffer(buffer);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].status).toBe("ok");
+  });
+
+  it("parses a complete result message", () => {
+    const result = {
+      summary: "Test summary",
+      tools: [{ name: "Tool1", category: "llm", reason: "Good" }],
+      diagram: "graph TD; A-->B",
+      buildSteps: ["Step 1"],
+      tradeoffs: ["Tradeoff 1"],
+    };
+    const buffer = `data: ${JSON.stringify({ status: "complete", result })}\n\n`;
+    const { messages } = parseSSEBuffer(buffer);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].result?.summary).toBe("Test summary");
+    expect(messages[0].result?.tools).toHaveLength(1);
+  });
+});

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure scoring functions extracted from collection scripts.
+ * Used by collect-github.ts, collect-hn.ts, and tests.
+ */
+
+export function calculateStarVelocity(
+  newerStars: number,
+  olderStars: number,
+  timeDiffMs: number
+): number {
+  const timeDiffDays = timeDiffMs / (1000 * 60 * 60 * 24);
+  if (timeDiffDays <= 0) return 0;
+  return (newerStars - olderStars) / timeDiffDays;
+}
+
+export function estimateInitialVelocity(stars: number): number {
+  // Rough estimate: assume repo is ~2 years old on average
+  return stars / 730;
+}
+
+export function calculateHNBoost(
+  totalPoints: number,
+  mentionCount: number
+): number {
+  return totalPoints * 0.1 + mentionCount * 2;
+}
+
+export function calculateOverallScore(
+  starVelocity: number,
+  hnBoost: number
+): number {
+  return starVelocity + hnBoost;
+}
+
+export function roundScore(value: number): number {
+  return Math.round(value * 100) / 100;
+}


### PR DESCRIPTION
## Summary
- **59 tests across 7 files** covering scoring logic, SSE utilities, mermaid validation, and all three API routes (generate, share, leaderboard)
- **CI workflow** (`.github/workflows/ci.yml`) running lint, test, and build on PRs and pushes to main
- **Scoring module extraction** (`src/lib/scoring.ts`) — pure functions pulled out of collect scripts for testability and reuse

## Context
Starting from 1 test file (6 tests), this establishes testing foundations for solo development. The scoring extraction also fixes a code duplication issue between `collect-github.ts` and `collect-hn.ts`.

## Test plan
- [x] All 59 tests pass (`npm run test`)
- [x] Lint passes with 0 errors/warnings (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] App verified working locally (leaderboard loads, generate flow completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)