### PR TITLE
feat: re-enable architecture generator API with rate limiting

### DIFF
--- a/src/app/api/generate/__tests__/route.test.ts
+++ b/src/app/api/generate/__tests__/route.test.ts
@@ -29,11 +29,15 @@ vi.mock("@anthropic-ai/sdk", () => {
 });
 
 import { POST } from "../route";
+import { _resetRateLimitStore } from "@/lib/rate-limit";
 
-function makeRequest(body: unknown): NextRequest {
+function makeRequest(body: unknown, ip: string = "127.0.0.1"): NextRequest {
   return new NextRequest("http://localhost:3001/api/generate", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "x-forwarded-for": ip,
+    },
     body: JSON.stringify(body),
   });
 }
@@ -56,6 +60,8 @@ describe("POST /api/generate", () => {
     mockGetTools.mockResolvedValue([]);
     // Set API key so tests reach the Anthropic code path
     process.env.ANTHROPIC_API_KEY = "test-key";
+    // Reset rate limiter between tests
+    _resetRateLimitStore();
   });
 
   it("returns 400 when prompt is missing", async () => {
@@ -150,5 +156,77 @@ describe("POST /api/generate", () => {
     const res = await POST(makeRequest({ prompt: "Build a chatbot" }));
     const fullText = await readStream(res);
     expect(fullText).toContain('"status":"error"');
+  });
+
+  it("returns 503 when ANTHROPIC_API_KEY is not set", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const res = await POST(makeRequest({ prompt: "Build a chatbot" }));
+    expect(res.status).toBe(503);
+    const data = await res.json();
+    expect(data.error).toContain("not configured");
+  });
+
+  describe("rate limiting", () => {
+    it("returns 429 after 10 requests from the same IP", async () => {
+      mockCreate.mockResolvedValue({
+        content: [
+          {
+            type: "tool_use",
+            name: "describe_architecture",
+            input: {
+              summary: "Test",
+              tools: [{ name: "T", category: "c", reason: "r" }],
+              diagramDescription: "d",
+              buildSteps: ["s"],
+              tradeoffs: ["t"],
+            },
+          },
+        ],
+      });
+
+      // Send 10 requests — all should succeed
+      for (let i = 0; i < 10; i++) {
+        const res = await POST(makeRequest({ prompt: "Build a chatbot" }, "10.0.0.1"));
+        expect(res.status).toBe(200);
+        // Consume stream to avoid hanging
+        await readStream(res);
+      }
+
+      // 11th request should be rate-limited
+      const res = await POST(makeRequest({ prompt: "Build a chatbot" }, "10.0.0.1"));
+      expect(res.status).toBe(429);
+      const data = await res.json();
+      expect(data.error).toContain("Too many requests");
+      expect(res.headers.get("Retry-After")).toBeTruthy();
+    });
+
+    it("allows requests from different IPs independently", async () => {
+      mockCreate.mockResolvedValue({
+        content: [
+          {
+            type: "tool_use",
+            name: "describe_architecture",
+            input: {
+              summary: "Test",
+              tools: [{ name: "T", category: "c", reason: "r" }],
+              diagramDescription: "d",
+              buildSteps: ["s"],
+              tradeoffs: ["t"],
+            },
+          },
+        ],
+      });
+
+      // Max out IP A
+      for (let i = 0; i < 10; i++) {
+        const res = await POST(makeRequest({ prompt: "Build a chatbot" }, "10.0.0.1"));
+        await readStream(res);
+      }
+
+      // IP B should still work
+      const res = await POST(makeRequest({ prompt: "Build a chatbot" }, "10.0.0.2"));
+      expect(res.status).toBe(200);
+      await readStream(res);
+    });
   });
 });

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -6,6 +6,7 @@ import {
   type GeneratedArchitectureResult,
 } from "@/lib/architecture";
 import { getToolsWithLatestMetrics } from "@/lib/queries";
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -97,30 +98,28 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid prompt" }, { status: 400 });
   }
 
-  // Anthropic API disabled — return friendly message (after input validation)
+  // Rate limit: 10 requests per minute per IP
+  const clientIp = getClientIp(request);
+  const { allowed, retryAfterMs } = checkRateLimit(clientIp, {
+    maxRequests: 10,
+    windowMs: 60_000,
+  });
+
+  if (!allowed) {
+    return NextResponse.json(
+      { error: "Too many requests. Please try again later." },
+      {
+        status: 429,
+        headers: { "Retry-After": String(Math.ceil(retryAfterMs / 1000)) },
+      }
+    );
+  }
+
   if (!process.env.ANTHROPIC_API_KEY) {
-    const encoder = new TextEncoder();
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(
-          encoder.encode(
-            sseMessage({
-              status: "error",
-              error:
-                "Architecture generation is temporarily disabled. Set ANTHROPIC_API_KEY to enable.",
-            })
-          )
-        );
-        controller.close();
-      },
-    });
-    return new Response(stream, {
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-      },
-    });
+    return NextResponse.json(
+      { error: "Architecture generation is not configured." },
+      { status: 503 }
+    );
   }
 
   const encoder = new TextEncoder();
@@ -201,7 +200,17 @@ Project description: ${prompt}`,
         });
       } catch (error) {
         console.error("Generate API error:", error);
-        send({ status: "error", error: "Failed to generate architecture" });
+        let message = "Failed to generate architecture. Please try again.";
+        if (error instanceof Error) {
+          if (error.name === "AbortError" || error.message.includes("timeout")) {
+            message = "Request timed out. Please try a simpler prompt.";
+          } else if ("status" in error && (error as { status: number }).status === 429) {
+            message = "AI service is busy. Please try again in a moment.";
+          } else if ("status" in error && (error as { status: number }).status >= 500) {
+            message = "AI service is temporarily unavailable. Please try again later.";
+          }
+        }
+        send({ status: "error", error: message });
       } finally {
         controller.close();
       }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,71 @@
+/**
+ * In-memory sliding-window rate limiter.
+ * Each IP gets a list of timestamps; requests outside the window are pruned on access.
+ */
+
+interface RateLimiterOptions {
+  /** Maximum requests allowed within the window */
+  maxRequests: number;
+  /** Window size in milliseconds */
+  windowMs: number;
+}
+
+const store = new Map<string, number[]>();
+
+// Periodic cleanup to prevent memory growth from stale entries
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+function ensureCleanupTimer(windowMs: number) {
+  if (cleanupTimer) return;
+  cleanupTimer = setInterval(() => {
+    const cutoff = Date.now() - windowMs;
+    for (const [key, timestamps] of store) {
+      const valid = timestamps.filter((t) => t > cutoff);
+      if (valid.length === 0) {
+        store.delete(key);
+      } else {
+        store.set(key, valid);
+      }
+    }
+  }, CLEANUP_INTERVAL_MS);
+  // Allow the process to exit without waiting for the timer
+  if (cleanupTimer && typeof cleanupTimer === "object" && "unref" in cleanupTimer) {
+    cleanupTimer.unref();
+  }
+}
+
+export function checkRateLimit(
+  key: string,
+  { maxRequests, windowMs }: RateLimiterOptions
+): { allowed: boolean; retryAfterMs: number } {
+  ensureCleanupTimer(windowMs);
+
+  const now = Date.now();
+  const cutoff = now - windowMs;
+  const timestamps = (store.get(key) ?? []).filter((t) => t > cutoff);
+
+  if (timestamps.length >= maxRequests) {
+    const oldest = timestamps[0];
+    const retryAfterMs = oldest + windowMs - now;
+    return { allowed: false, retryAfterMs };
+  }
+
+  timestamps.push(now);
+  store.set(key, timestamps);
+  return { allowed: true, retryAfterMs: 0 };
+}
+
+/** Extract client IP from request headers */
+export function getClientIp(request: Request): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    return forwarded.split(",")[0].trim();
+  }
+  return request.headers.get("x-real-ip") ?? "unknown";
+}
+
+/** Reset the store — for testing only */
+export function _resetRateLimitStore() {
+  store.clear();
+}


### PR DESCRIPTION
## Summary
- Removes the "temporarily disabled" SSE guard from `/api/generate`, replacing it with a proper 503 response when `ANTHROPIC_API_KEY` is not configured
- Adds IP-based rate limiting (10 requests/min per IP) with `429` responses and `Retry-After` header
- Improves error handling with specific messages for timeouts, upstream rate limits (Anthropic 429), and service errors (5xx)

## Changes
- **`src/app/api/generate/route.ts`** — removed disabled guard, added rate limit check, improved catch block with categorized error messages
- **`src/lib/rate-limit.ts`** — new in-memory sliding-window rate limiter with periodic cleanup
- **`src/app/api/generate/__tests__/route.test.ts`** — added tests for 503 on missing API key, 429 rate limiting, and per-IP independence

## Test plan
- [x] All 76 existing + new tests pass (`npm run test`)
- [x] Build succeeds (`npm run build`)
- [x] Lint passes with no new warnings (`npm run lint`)
- [ ] E2E: prompt → SSE streaming → tools selected → diagram generated → shareable (requires `ANTHROPIC_API_KEY`)
- [ ] Rate limit: verify 11th request in 1 minute returns 429

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)