### PR TITLE
fix: add checkout step to claude-review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -14,6 +14,9 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds `actions/checkout@v4` step before `anthropics/claude-code-action` in the review workflow
- The action needs a git repo to compute file SHAs and review PR diffs

## Test plan
- [x] Verify the `review` CI check passes on subsequent PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)