### PR TITLE
fix: make claude-review job non-blocking

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,6 +8,7 @@ jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Adds `continue-on-error: true` to the claude-review job so it doesn't block PR merges when `ANTHROPIC_API_KEY` is not configured

## Why
The review job fails on every PR with `Environment variable validation failed: Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required`. This blocks all PRs from passing CI checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)