### PR TITLE
fix: skip claude review when API key is not configured

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,6 +8,7 @@ jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write
@@ -17,7 +18,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Check for API key
+        id: check-key
+        run: |
+          if [ -n "${{ secrets.ANTHROPIC_API_KEY }}" ]; then
+            echo "has_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Claude review — ANTHROPIC_API_KEY not configured"
+          fi
       - uses: anthropics/claude-code-action@beta
+        if: steps.check-key.outputs.has_key == 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           direct_prompt: |


### PR DESCRIPTION
## Summary
- Adds a pre-check step to detect if `ANTHROPIC_API_KEY` is set before running the claude-code-action
- Skips the review step gracefully when the secret is missing
- Adds `continue-on-error: true` to the job so it never blocks PR merges

## Why
Every PR in this repo fails CI because the review job errors out with "ANTHROPIC_API_KEY is required". This blocks all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)