### PR TITLE
feat: add weekly AI tools momentum summary to leaderboard

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { LeaderboardTable } from "@/components/leaderboard-table";
 import { LeaderboardTabs } from "@/components/leaderboard-tabs";
 import { EssentialsView } from "@/components/essentials-view";
+import { WeeklySummaryCard } from "@/components/weekly-summary";
 import { Trophy, BookOpen } from "lucide-react";
 
 export const dynamic = "force-dynamic";
@@ -85,6 +86,16 @@ export default async function LeaderboardPage({
 
   const tools = activeView === "momentum" ? await getLeaderboardData() : [];
 
+  let weeklySummary = null;
+  if (activeView === "momentum" && tools.length > 0) {
+    try {
+      const { getWeeklySummaryData } = await import("@/lib/queries");
+      weeklySummary = await getWeeklySummaryData();
+    } catch {
+      // Summary is non-critical, page works without it
+    }
+  }
+
   return (
     <div className="max-w-6xl mx-auto px-6 py-12">
       <div className="mb-10 animate-fade-in-up">
@@ -132,9 +143,16 @@ export default async function LeaderboardPage({
 
       {activeView === "momentum" ? (
         tools.length > 0 ? (
-          <div className="animate-fade-in-up delay-100">
-            <LeaderboardTable initialTools={tools} />
-          </div>
+          <>
+            {weeklySummary && (
+              <div className="animate-fade-in-up delay-100">
+                <WeeklySummaryCard data={weeklySummary} />
+              </div>
+            )}
+            <div className="animate-fade-in-up delay-200">
+              <LeaderboardTable initialTools={tools} />
+            </div>
+          </>
         ) : (
           <div className="text-center py-24" style={{ color: "var(--text-tertiary)" }}>
             <p className="text-base mb-2" style={{ color: "var(--text-secondary)" }}>

--- a/src/components/weekly-summary.tsx
+++ b/src/components/weekly-summary.tsx
@@ -1,0 +1,191 @@
+import { TrendingUp, TrendingDown, Sparkles, BarChart3 } from "lucide-react";
+import type { WeeklySummary } from "@/lib/queries";
+
+export function WeeklySummaryCard({ data }: { data: WeeklySummary }) {
+  const hasContent =
+    data.trendingUp.length > 0 ||
+    data.trendingDown.length > 0 ||
+    data.newThisWeek.length > 0;
+
+  if (!hasContent) return null;
+
+  const title = data.hasHistoricalData ? "This Week in AI Tools" : "Top Movers";
+
+  return (
+    <div className="card p-5 mb-6">
+      <div className="flex items-center gap-2 mb-4">
+        <div
+          className="w-7 h-7 rounded-lg flex items-center justify-center"
+          style={{
+            background: "rgba(34, 197, 94, 0.1)",
+            border: "1px solid rgba(34, 197, 94, 0.2)",
+          }}
+        >
+          <BarChart3 className="w-3.5 h-3.5" style={{ color: "var(--accent-green)" }} />
+        </div>
+        <h2
+          className="text-sm font-semibold"
+          style={{
+            fontFamily: "var(--font-syne), sans-serif",
+            color: "var(--text-primary)",
+          }}
+        >
+          {title}
+        </h2>
+        {data.hasHistoricalData && data.dataAge && (
+          <span
+            className="text-xs ml-auto"
+            style={{
+              color: "var(--text-tertiary)",
+              fontFamily: "var(--font-jetbrains-mono), monospace",
+            }}
+          >
+            vs {data.dataAge} ago
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {/* Trending Up */}
+        {data.trendingUp.length > 0 && (
+          <div>
+            <div className="flex items-center gap-1.5 mb-2.5">
+              <TrendingUp
+                className="w-3.5 h-3.5"
+                style={{ color: "var(--accent-green)" }}
+              />
+              <span
+                className="text-xs font-medium"
+                style={{ color: "var(--accent-green)" }}
+              >
+                {data.hasHistoricalData ? "Trending Up" : "Highest Momentum"}
+              </span>
+            </div>
+            <div className="space-y-1.5">
+              {data.trendingUp.map((tool) => (
+                <a
+                  key={tool.repo}
+                  href={`https://github.com/${tool.repo}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-between py-1.5 px-2.5 rounded-lg transition-colors"
+                  style={{ background: "var(--accent-green-dim)" }}
+                >
+                  <span
+                    className="text-xs font-medium truncate"
+                    style={{ color: "var(--text-primary)" }}
+                  >
+                    {tool.name}
+                  </span>
+                  <span
+                    className="text-xs font-mono shrink-0 ml-2"
+                    style={{
+                      color: "var(--accent-green)",
+                      fontFamily: "var(--font-jetbrains-mono), monospace",
+                    }}
+                  >
+                    {data.hasHistoricalData
+                      ? `+${tool.delta.toFixed(1)}`
+                      : tool.currentScore.toFixed(1)}
+                  </span>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Trending Down */}
+        {data.trendingDown.length > 0 && (
+          <div>
+            <div className="flex items-center gap-1.5 mb-2.5">
+              <TrendingDown
+                className="w-3.5 h-3.5"
+                style={{ color: "var(--accent-red)" }}
+              />
+              <span
+                className="text-xs font-medium"
+                style={{ color: "var(--accent-red)" }}
+              >
+                Trending Down
+              </span>
+            </div>
+            <div className="space-y-1.5">
+              {data.trendingDown.map((tool) => (
+                <a
+                  key={tool.repo}
+                  href={`https://github.com/${tool.repo}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-between py-1.5 px-2.5 rounded-lg transition-colors"
+                  style={{ background: "rgba(239, 68, 68, 0.06)" }}
+                >
+                  <span
+                    className="text-xs font-medium truncate"
+                    style={{ color: "var(--text-primary)" }}
+                  >
+                    {tool.name}
+                  </span>
+                  <span
+                    className="text-xs font-mono shrink-0 ml-2"
+                    style={{
+                      color: "var(--accent-red)",
+                      fontFamily: "var(--font-jetbrains-mono), monospace",
+                    }}
+                  >
+                    {tool.delta.toFixed(1)}
+                  </span>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* New This Week */}
+        {data.newThisWeek.length > 0 && (
+          <div>
+            <div className="flex items-center gap-1.5 mb-2.5">
+              <Sparkles
+                className="w-3.5 h-3.5"
+                style={{ color: "var(--accent-amber)" }}
+              />
+              <span
+                className="text-xs font-medium"
+                style={{ color: "var(--accent-amber)" }}
+              >
+                New This Week
+              </span>
+            </div>
+            <div className="space-y-1.5">
+              {data.newThisWeek.map((tool) => (
+                <a
+                  key={tool.repo}
+                  href={`https://github.com/${tool.repo}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-between py-1.5 px-2.5 rounded-lg transition-colors"
+                  style={{ background: "var(--accent-amber-dim)" }}
+                >
+                  <span
+                    className="text-xs font-medium truncate"
+                    style={{ color: "var(--text-primary)" }}
+                  >
+                    {tool.name}
+                  </span>
+                  <span
+                    className="text-xs font-mono shrink-0 ml-2"
+                    style={{
+                      color: "var(--accent-amber)",
+                      fontFamily: "var(--font-jetbrains-mono), monospace",
+                    }}
+                  >
+                    {tool.score.toFixed(1)}
+                  </span>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -2,6 +2,25 @@ import { db } from "./db";
 import { tools, momentumScores, githubSnapshots } from "./schema";
 import { desc, eq, sql } from "drizzle-orm";
 
+// ─── Weekly Summary Types ───────────────────────────────────────────────
+
+export type ToolDelta = {
+  name: string;
+  repo: string;
+  category: string;
+  currentScore: number;
+  previousScore: number;
+  delta: number;
+};
+
+export type WeeklySummary = {
+  trendingUp: ToolDelta[];
+  trendingDown: ToolDelta[];
+  newThisWeek: { name: string; repo: string; category: string; score: number }[];
+  hasHistoricalData: boolean;
+  dataAge: string;
+};
+
 export type ToolWithMetrics = {
   id: number;
   name: string;
@@ -93,4 +112,142 @@ export async function getToolsWithLatestMetrics(): Promise<ToolWithMetrics[]> {
       lastUpdated: score?.calculated_at ?? null,
     };
   });
+}
+
+// ─── Weekly Summary Query ──────────────────────────────────────────────
+
+type OldScoreRow = {
+  tool_id: number;
+  overall_score: number;
+  calculated_at: Date;
+};
+
+/**
+ * Computes a weekly momentum summary by comparing current scores
+ * against the closest snapshot from ~7 days ago.
+ */
+export async function getWeeklySummaryData(): Promise<WeeklySummary> {
+  const allTools = await db.select().from(tools);
+  const toolMap = new Map(allTools.map((t) => [t.id, t]));
+
+  // Latest score per tool
+  const latestScores: ScoreRow[] = await db.execute(sql`
+    SELECT DISTINCT ON (tool_id)
+      tool_id, star_velocity, hn_mentions_7d, hn_points_7d,
+      npm_downloads_7d, pypi_downloads_7d, overall_score, calculated_at
+    FROM momentum_scores
+    ORDER BY tool_id, calculated_at DESC
+  `);
+
+  // Scores from ~7 days ago: get the latest score per tool that is at least 6 days old
+  const oldScores: OldScoreRow[] = await db.execute(sql`
+    SELECT DISTINCT ON (tool_id)
+      tool_id, overall_score, calculated_at
+    FROM momentum_scores
+    WHERE calculated_at < NOW() - INTERVAL '6 days'
+    ORDER BY tool_id, calculated_at DESC
+  `);
+
+  // Tools created in the last 7 days
+  const newToolRows: { id: number }[] = await db.execute(sql`
+    SELECT id FROM tools
+    WHERE created_at > NOW() - INTERVAL '7 days'
+  `);
+  const newToolIds = new Set(newToolRows.map((r) => r.id));
+
+  const oldScoreMap = new Map(oldScores.map((s) => [s.tool_id, s.overall_score]));
+  const hasHistoricalData = oldScores.length > 0;
+
+  // Compute age of oldest comparison data
+  let dataAge = "";
+  if (hasHistoricalData) {
+    const oldestDate = oldScores.reduce(
+      (min, s) => (s.calculated_at < min ? s.calculated_at : min),
+      oldScores[0].calculated_at
+    );
+    const days = Math.round((Date.now() - oldestDate.getTime()) / (1000 * 60 * 60 * 24));
+    dataAge = `${days}d`;
+  }
+
+  const deltas: ToolDelta[] = [];
+
+  for (const score of latestScores) {
+    const tool = toolMap.get(score.tool_id);
+    if (!tool) continue;
+    if (newToolIds.has(tool.id)) continue; // exclude new tools from delta calc
+
+    const previousScore = oldScoreMap.get(score.tool_id);
+    if (previousScore === undefined) continue; // no historical data for this tool
+
+    deltas.push({
+      name: tool.name,
+      repo: tool.repo,
+      category: tool.category,
+      currentScore: score.overall_score,
+      previousScore,
+      delta: Math.round((score.overall_score - previousScore) * 100) / 100,
+    });
+  }
+
+  // Sort by delta descending for trending up
+  const sortedUp = [...deltas]
+    .filter((d) => d.delta > 0)
+    .sort((a, b) => b.delta - a.delta)
+    .slice(0, 5);
+
+  // Sort by delta ascending for trending down
+  const sortedDown = [...deltas]
+    .filter((d) => d.delta < 0)
+    .sort((a, b) => a.delta - b.delta)
+    .slice(0, 3);
+
+  // New this week
+  const newThisWeek = latestScores
+    .filter((s) => newToolIds.has(s.tool_id))
+    .map((s) => {
+      const tool = toolMap.get(s.tool_id)!;
+      return {
+        name: tool.name,
+        repo: tool.repo,
+        category: tool.category,
+        score: s.overall_score,
+      };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  // Fallback: if no historical data, show top movers by current score
+  if (!hasHistoricalData) {
+    const topMovers = latestScores
+      .map((s) => {
+        const tool = toolMap.get(s.tool_id);
+        if (!tool) return null;
+        return {
+          name: tool.name,
+          repo: tool.repo,
+          category: tool.category,
+          currentScore: s.overall_score,
+          previousScore: 0,
+          delta: s.overall_score,
+        };
+      })
+      .filter((d): d is ToolDelta => d !== null)
+      .sort((a, b) => b.currentScore - a.currentScore)
+      .slice(0, 5);
+
+    return {
+      trendingUp: topMovers,
+      trendingDown: [],
+      newThisWeek,
+      hasHistoricalData: false,
+      dataAge: "",
+    };
+  }
+
+  return {
+    trendingUp: sortedUp,
+    trendingDown: sortedDown,
+    newThisWeek,
+    hasHistoricalData: true,
+    dataAge,
+  };
 }


### PR DESCRIPTION
## Summary
- Adds a "This Week in AI Tools" summary card at the top of the momentum leaderboard view
- Compares current momentum scores against ~7-day-old snapshots to show **Trending Up** (top 5), **Trending Down** (top 3), and **New This Week** sections
- Falls back to a "Top Movers" view (by current score) when no historical data exists yet
- Uses existing `momentum_scores` time-series data — no schema changes needed

## Implementation
- **`src/lib/queries.ts`** — new `getWeeklySummaryData()` query using `DISTINCT ON` to efficiently fetch current vs previous scores
- **`src/components/weekly-summary.tsx`** — server component with 3-column grid layout using existing design tokens
- **`src/app/leaderboard/page.tsx`** — integrates summary card above the leaderboard table (momentum view only)

## Test plan
- [x] `npm run build` passes (type-check clean)
- [x] `npm run test` — all 73 tests pass
- [x] `npm run lint` — no new warnings
- [ ] Browser-check the momentum leaderboard with data present
- [ ] Verify fallback "Top Movers" view when no 7-day historical data exists
- [ ] Verify card hides gracefully when no momentum data at all

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)