### PR TITLE
feat: simplify workflow submission form from 5 steps to 2

### DIFF
--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -1,12 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import {
-  workflows,
-  workflowTools,
-  tools,
-  users,
-  type WorkflowStep,
-} from "@/lib/schema";
+import { workflows, workflowTools, tools, users, type WorkflowStep } from "@/lib/schema";
 import { desc, eq, ilike, or, sql } from "drizzle-orm";
 import { getFingerprint } from "@/lib/fingerprint";
 
@@ -94,10 +88,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ workflows: results, page, limit });
   } catch (error) {
     console.error("Workflows GET error:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch workflows" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to fetch workflows" }, { status: 500 });
   }
 }
 
@@ -110,23 +101,29 @@ export async function POST(request: NextRequest) {
     const title = String(body.title ?? "").trim();
     const description = String(body.description ?? "").trim();
     const difficulty = String(body.difficulty ?? "");
-    const submitterName = String(body.submitterName ?? "").trim();
+    const submitterName = String(body.submitterName ?? "").trim() || "Anonymous";
     const steps = body.steps as WorkflowStep[] | undefined;
 
     if (!title || title.length < 5) {
-      return NextResponse.json({ error: "Title must be at least 5 characters" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Title must be at least 5 characters" },
+        { status: 400 }
+      );
     }
     if (!description || description.length < 10) {
-      return NextResponse.json({ error: "Description must be at least 10 characters" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Description must be at least 10 characters" },
+        { status: 400 }
+      );
     }
     if (!["beginner", "intermediate", "advanced"].includes(difficulty)) {
       return NextResponse.json({ error: "Invalid difficulty" }, { status: 400 });
     }
-    if (!submitterName) {
-      return NextResponse.json({ error: "Name is required" }, { status: 400 });
-    }
     if (!steps || !Array.isArray(steps) || steps.length === 0) {
-      return NextResponse.json({ error: "At least one step is required" }, { status: 400 });
+      return NextResponse.json(
+        { error: "At least one step is required" },
+        { status: 400 }
+      );
     }
 
     const fingerprintHash = await getFingerprint();
@@ -211,9 +208,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ slug: workflow.slug }, { status: 201 });
   } catch (error) {
     console.error("Workflow POST error:", error);
-    return NextResponse.json(
-      { error: "Failed to create workflow" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to create workflow" }, { status: 500 });
   }
 }

--- a/src/components/workflow-form.tsx
+++ b/src/components/workflow-form.tsx
@@ -2,15 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import {
-  ArrowRight,
-  ArrowLeft,
-  Plus,
-  X,
-  Search,
-  Check,
-  Loader2,
-} from "lucide-react";
+import { ArrowRight, ArrowLeft, Plus, X, Search, Check, Loader2 } from "lucide-react";
 
 interface AvailableTool {
   id: number;
@@ -18,55 +10,27 @@ interface AvailableTool {
   category: string;
 }
 
-interface SelectedTool {
-  id: number;
-  name: string;
-  role: string;
-}
-
-interface StepData {
-  title: string;
-  description: string;
-  toolName: string;
-  promptText: string;
-}
-
 interface FormData {
   title: string;
   description: string;
-  problemContext: string;
   difficulty: "beginner" | "intermediate" | "advanced";
-  timeSaved: string;
-  selectedTools: SelectedTool[];
-  steps: StepData[];
-  outcome: string;
-  failureModes: string;
-  proofUrls: string[];
-  submitterName: string;
-  submitterRole: string;
+  selectedTools: { id: number; name: string }[];
+  steps: string[];
+  proofUrl: string;
 }
 
 const INITIAL_FORM: FormData = {
   title: "",
   description: "",
-  problemContext: "",
   difficulty: "intermediate",
-  timeSaved: "",
   selectedTools: [],
-  steps: [{ title: "", description: "", toolName: "", promptText: "" }],
-  outcome: "",
-  failureModes: "",
-  proofUrls: [""],
-  submitterName: "",
-  submitterRole: "",
+  steps: [""],
+  proofUrl: "",
 };
 
 const STEPS = [
   { n: 1, label: "Basics" },
-  { n: 2, label: "Tools" },
-  { n: 3, label: "Steps" },
-  { n: 4, label: "Results" },
-  { n: 5, label: "Submit" },
+  { n: 2, label: "Steps & Submit" },
 ];
 
 const DIFFICULTY_OPTIONS = [
@@ -87,11 +51,7 @@ const DIFFICULTY_OPTIONS = [
   },
 ];
 
-export function WorkflowForm({
-  availableTools,
-}: {
-  availableTools: AvailableTool[];
-}) {
+export function WorkflowForm({ availableTools }: { availableTools: AvailableTool[] }) {
   const router = useRouter();
   const [step, setStep] = useState(1);
   const [form, setForm] = useState<FormData>(INITIAL_FORM);
@@ -99,35 +59,26 @@ export function WorkflowForm({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
 
-  // --- Field updaters ---
-  const update = useCallback(
-    <K extends keyof FormData>(key: K, value: FormData[K]) => {
-      setForm((prev) => ({ ...prev, [key]: value }));
-    },
-    []
-  );
-
-  const updateStep = useCallback(
-    (index: number, field: keyof StepData, value: string) => {
-      setForm((prev) => {
-        const steps = [...prev.steps];
-        steps[index] = { ...steps[index], [field]: value };
-        return { ...prev, steps };
-      });
-    },
-    []
-  );
+  const update = useCallback(<K extends keyof FormData>(key: K, value: FormData[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }, []);
 
   // --- Validation per step ---
   function canAdvance(): boolean {
-    if (step === 1) return form.title.length >= 5 && form.description.length >= 10;
-    if (step === 2) return form.selectedTools.length >= 1;
-    if (step === 3) return form.steps.some((s) => s.title && s.description);
-    if (step === 4) return form.submitterName.trim().length > 0;
+    if (step === 1)
+      return (
+        form.title.length >= 5 &&
+        form.description.length >= 10 &&
+        form.selectedTools.length >= 1
+      );
     return true;
   }
 
-  // --- Tool toggling ---
+  function canSubmit(): boolean {
+    return form.steps.some((s) => s.trim().length > 0);
+  }
+
+  // --- Tool toggling (tag-style) ---
   function toggleTool(tool: { id: number; name: string }) {
     setForm((prev) => {
       const exists = prev.selectedTools.find((t) => t.id === tool.id);
@@ -139,32 +90,22 @@ export function WorkflowForm({
       }
       return {
         ...prev,
-        selectedTools: [
-          ...prev.selectedTools,
-          { id: tool.id, name: tool.name, role: "" },
-        ],
+        selectedTools: [...prev.selectedTools, { id: tool.id, name: tool.name }],
       };
     });
   }
 
-  function updateToolRole(id: number, role: string) {
-    setForm((prev) => ({
-      ...prev,
-      selectedTools: prev.selectedTools.map((t) =>
-        t.id === id ? { ...t, role } : t
-      ),
-    }));
+  // --- Step list management ---
+  function updateStepText(index: number, value: string) {
+    setForm((prev) => {
+      const steps = [...prev.steps];
+      steps[index] = value;
+      return { ...prev, steps };
+    });
   }
 
-  // --- Step list management ---
   function addStep() {
-    setForm((prev) => ({
-      ...prev,
-      steps: [
-        ...prev.steps,
-        { title: "", description: "", toolName: "", promptText: "" },
-      ],
-    }));
+    setForm((prev) => ({ ...prev, steps: [...prev.steps, ""] }));
   }
 
   function removeStep(index: number) {
@@ -172,27 +113,6 @@ export function WorkflowForm({
     setForm((prev) => ({
       ...prev,
       steps: prev.steps.filter((_, i) => i !== index),
-    }));
-  }
-
-  // --- Proof URL management ---
-  function addProofUrl() {
-    setForm((prev) => ({ ...prev, proofUrls: [...prev.proofUrls, ""] }));
-  }
-
-  function updateProofUrl(index: number, value: string) {
-    setForm((prev) => {
-      const urls = [...prev.proofUrls];
-      urls[index] = value;
-      return { ...prev, proofUrls: urls };
-    });
-  }
-
-  function removeProofUrl(index: number) {
-    if (form.proofUrls.length <= 1) return;
-    setForm((prev) => ({
-      ...prev,
-      proofUrls: prev.proofUrls.filter((_, i) => i !== index),
     }));
   }
 
@@ -208,27 +128,16 @@ export function WorkflowForm({
         body: JSON.stringify({
           title: form.title,
           description: form.description,
-          problemContext: form.problemContext || undefined,
           difficulty: form.difficulty,
-          timeSaved: form.timeSaved || undefined,
-          toolIds: form.selectedTools.map((t) => ({
-            id: t.id,
-            role: t.role || undefined,
-          })),
+          toolIds: form.selectedTools.map((t) => ({ id: t.id })),
           steps: form.steps
-            .filter((s) => s.title || s.description)
+            .filter((s) => s.trim())
             .map((s, i) => ({
               order: i + 1,
-              title: s.title,
-              description: s.description,
-              toolName: s.toolName || undefined,
-              promptText: s.promptText || undefined,
+              title: s.trim(),
+              description: s.trim(),
             })),
-          outcome: form.outcome || undefined,
-          failureModes: form.failureModes || undefined,
-          proofUrls: form.proofUrls.filter(Boolean),
-          submitterName: form.submitterName,
-          submitterRole: form.submitterRole || undefined,
+          proofUrls: form.proofUrl.trim() ? [form.proofUrl.trim()] : [],
         }),
       });
 
@@ -256,13 +165,10 @@ export function WorkflowForm({
       )
     : availableTools;
 
-  // --- Tool names for step dropdown ---
-  const selectedToolNames = form.selectedTools.map((t) => t.name);
-
   return (
     <div className="max-w-2xl mx-auto">
       {/* Progress */}
-      <div className="flex items-center justify-between mb-12 px-2">
+      <div className="flex items-center justify-center mb-12 px-2">
         {STEPS.map((s, i) => (
           <div key={s.n} className="flex items-center">
             <button
@@ -300,12 +206,9 @@ export function WorkflowForm({
                 {s.n < step ? <Check className="w-3.5 h-3.5" /> : s.n}
               </span>
               <span
-                className="text-xs font-medium hidden sm:inline"
+                className="text-xs font-medium"
                 style={{
-                  color:
-                    s.n === step
-                      ? "var(--text-primary)"
-                      : "var(--text-tertiary)",
+                  color: s.n === step ? "var(--text-primary)" : "var(--text-tertiary)",
                 }}
               >
                 {s.label}
@@ -313,10 +216,9 @@ export function WorkflowForm({
             </button>
             {i < STEPS.length - 1 && (
               <div
-                className="w-8 sm:w-12 h-px mx-2"
+                className="w-12 sm:w-20 h-px mx-3"
                 style={{
-                  background:
-                    s.n < step ? "var(--accent-green)" : "var(--border-subtle)",
+                  background: s.n < step ? "var(--accent-green)" : "var(--border-subtle)",
                 }}
               />
             )}
@@ -326,7 +228,7 @@ export function WorkflowForm({
 
       {/* Step content */}
       <div className="animate-fade-in" key={step}>
-        {/* ---- STEP 1: Basics ---- */}
+        {/* ---- STEP 1: Basics + Tools ---- */}
         {step === 1 && (
           <div className="space-y-6">
             <div>
@@ -337,7 +239,7 @@ export function WorkflowForm({
                 Describe your workflow
               </h2>
               <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                What&rsquo;s the technique, setup, or workflow you use to ship faster with AI?
+                What&rsquo;s the technique or setup you use to ship faster with AI?
               </p>
             </div>
 
@@ -347,28 +249,17 @@ export function WorkflowForm({
                 type="text"
                 value={form.title}
                 onChange={(e) => update("title", e.target.value)}
-                placeholder="e.g., Parallel Claude Code sessions with agent orchestrator"
+                placeholder="e.g., Parallel Claude Code sessions for full-stack features"
                 className="input-base w-full px-4 py-3 rounded-xl text-sm"
               />
             </div>
 
             <div>
-              <Label>Short Description</Label>
+              <Label>Description</Label>
               <textarea
                 value={form.description}
                 onChange={(e) => update("description", e.target.value)}
-                placeholder="A 1-2 sentence summary of what this workflow does and why it matters."
-                rows={2}
-                className="input-base w-full px-4 py-3 rounded-xl text-sm resize-none"
-              />
-            </div>
-
-            <div>
-              <Label optional>Problem This Solves</Label>
-              <textarea
-                value={form.problemContext}
-                onChange={(e) => update("problemContext", e.target.value)}
-                placeholder="What were you struggling with before you figured this out?"
+                placeholder="e.g., Use multiple Claude Code instances in parallel — one for frontend, one for backend, one for tests — to ship full features in a single session."
                 rows={3}
                 className="input-base w-full px-4 py-3 rounded-xl text-sm resize-none"
               />
@@ -416,20 +307,84 @@ export function WorkflowForm({
               </div>
             </div>
 
+            {/* Tools — tag-style picker */}
             <div>
-              <Label optional>Time Saved</Label>
-              <input
-                type="text"
-                value={form.timeSaved}
-                onChange={(e) => update("timeSaved", e.target.value)}
-                placeholder="e.g., 3 hours per PR review"
-                className="input-base w-full px-4 py-3 rounded-xl text-sm"
-              />
+              <Label>Tools Used</Label>
+              <p className="text-xs mb-3" style={{ color: "var(--text-tertiary)" }}>
+                Select the AI tools this workflow uses. Pick at least one.
+              </p>
+
+              {/* Selected tools as tags */}
+              {form.selectedTools.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mb-3">
+                  {form.selectedTools.map((tool) => (
+                    <button
+                      key={tool.id}
+                      onClick={() => toggleTool(tool)}
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-all"
+                      style={{
+                        background: "var(--accent-cyan-dim)",
+                        color: "var(--text-primary)",
+                        border: "1px solid var(--text-primary)",
+                      }}
+                    >
+                      {tool.name}
+                      <X className="w-3 h-3" />
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {/* Tool search */}
+              <div className="relative mb-2">
+                <Search
+                  className="absolute left-3.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5"
+                  style={{ color: "var(--text-tertiary)" }}
+                />
+                <input
+                  type="text"
+                  value={toolSearch}
+                  onChange={(e) => setToolSearch(e.target.value)}
+                  placeholder="Search tools..."
+                  className="input-base w-full pl-10 pr-4 py-2.5 rounded-xl text-xs"
+                />
+              </div>
+
+              {/* Tool grid */}
+              <div
+                className="flex flex-wrap gap-1.5 max-h-48 overflow-y-auto pr-1 py-1"
+                style={{
+                  scrollbarWidth: "thin",
+                  scrollbarColor: "var(--border-default) transparent",
+                }}
+              >
+                {filteredTools.map((tool) => {
+                  const selected = form.selectedTools.some((t) => t.id === tool.id);
+                  return (
+                    <button
+                      key={tool.id}
+                      onClick={() => toggleTool(tool)}
+                      className="px-2.5 py-1.5 rounded-lg text-xs transition-all"
+                      style={{
+                        background: selected
+                          ? "var(--accent-cyan-dim)"
+                          : "var(--bg-surface)",
+                        border: `1px solid ${
+                          selected ? "var(--text-primary)" : "var(--border-subtle)"
+                        }`,
+                        color: selected ? "var(--text-primary)" : "var(--text-secondary)",
+                      }}
+                    >
+                      {tool.name}
+                    </button>
+                  );
+                })}
+              </div>
             </div>
           </div>
         )}
 
-        {/* ---- STEP 2: Tools ---- */}
+        {/* ---- STEP 2: Steps + Proof + Submit ---- */}
         {step === 2 && (
           <div className="space-y-6">
             <div>
@@ -437,220 +392,49 @@ export function WorkflowForm({
                 className="text-xl font-bold mb-1"
                 style={{ fontFamily: "var(--font-syne), sans-serif" }}
               >
-                Tools & Stack
+                How does it work?
               </h2>
               <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                Which AI tools does this workflow use? Select at least one.
+                List the steps someone would follow to replicate your workflow.
               </p>
             </div>
 
-            {/* Selected tools with roles */}
-            {form.selectedTools.length > 0 && (
-              <div className="space-y-2">
-                <Label>Selected ({form.selectedTools.length})</Label>
-                {form.selectedTools.map((tool) => (
-                  <div
-                    key={tool.id}
-                    className="flex items-center gap-3 p-3 rounded-xl"
+            <div className="space-y-2">
+              {form.steps.map((s, i) => (
+                <div key={i} className="flex items-start gap-2">
+                  <span
+                    className="flex-shrink-0 w-6 h-6 mt-2.5 rounded-md flex items-center justify-center text-[10px] font-bold"
                     style={{
-                      background: "var(--bg-surface)",
-                      border: "1px solid var(--text-primary)",
+                      background: "var(--accent-cyan-dim)",
+                      color: "var(--text-primary)",
+                      border: "1px solid var(--border-default)",
+                      fontFamily: "var(--font-jetbrains-mono), monospace",
                     }}
                   >
-                    <span
-                      className="text-sm font-medium shrink-0"
-                      style={{ color: "var(--text-primary)" }}
-                    >
-                      {tool.name}
-                    </span>
-                    <input
-                      type="text"
-                      value={tool.role}
-                      onChange={(e) => updateToolRole(tool.id, e.target.value)}
-                      placeholder="Role in workflow (optional)"
-                      className="flex-1 bg-transparent text-xs outline-none"
-                      style={{
-                        color: "var(--text-secondary)",
-                        borderBottom: "1px solid var(--border-subtle)",
-                        paddingBottom: 2,
-                      }}
-                    />
+                    {i + 1}
+                  </span>
+                  <input
+                    type="text"
+                    value={s}
+                    onChange={(e) => updateStepText(i, e.target.value)}
+                    placeholder={
+                      i === 0
+                        ? "e.g., Open three Claude Code sessions in separate terminal panes"
+                        : i === 1
+                          ? "e.g., Assign each session a specific role (frontend, backend, tests)"
+                          : "e.g., Use a shared CLAUDE.md to keep all agents aligned"
+                    }
+                    className="input-base flex-1 px-4 py-2.5 rounded-xl text-sm"
+                  />
+                  {form.steps.length > 1 && (
                     <button
-                      onClick={() => toggleTool(tool)}
-                      className="p-1 rounded-md transition-colors"
+                      onClick={() => removeStep(i)}
+                      className="p-2 mt-1.5 rounded-md transition-colors"
                       style={{ color: "var(--text-tertiary)" }}
                     >
                       <X className="w-3.5 h-3.5" />
                     </button>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Tool search */}
-            <div className="relative">
-              <Search
-                className="absolute left-3.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5"
-                style={{ color: "var(--text-tertiary)" }}
-              />
-              <input
-                type="text"
-                value={toolSearch}
-                onChange={(e) => setToolSearch(e.target.value)}
-                placeholder="Search tools..."
-                className="input-base w-full pl-10 pr-4 py-2.5 rounded-xl text-xs"
-              />
-            </div>
-
-            {/* Tool grid */}
-            <div
-              className="grid grid-cols-2 sm:grid-cols-3 gap-2 max-h-64 overflow-y-auto pr-1"
-              style={{
-                scrollbarWidth: "thin",
-                scrollbarColor: "var(--border-default) transparent",
-              }}
-            >
-              {filteredTools.map((tool) => {
-                const selected = form.selectedTools.some(
-                  (t) => t.id === tool.id
-                );
-                return (
-                  <button
-                    key={tool.id}
-                    onClick={() => toggleTool(tool)}
-                    className="px-3 py-2.5 rounded-lg text-left transition-all"
-                    style={{
-                      background: selected
-                        ? "var(--accent-cyan-dim)"
-                        : "var(--bg-surface)",
-                      border: `1px solid ${
-                        selected
-                          ? "var(--text-primary)"
-                          : "var(--border-subtle)"
-                      }`,
-                    }}
-                  >
-                    <span
-                      className="text-xs font-medium block truncate"
-                      style={{
-                        color: selected
-                          ? "var(--text-primary)"
-                          : "var(--text-secondary)",
-                      }}
-                    >
-                      {tool.name}
-                    </span>
-                    <span
-                      className="text-[10px] block truncate"
-                      style={{ color: "var(--text-tertiary)" }}
-                    >
-                      {tool.category}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        )}
-
-        {/* ---- STEP 3: Steps ---- */}
-        {step === 3 && (
-          <div className="space-y-6">
-            <div>
-              <h2
-                className="text-xl font-bold mb-1"
-                style={{ fontFamily: "var(--font-syne), sans-serif" }}
-              >
-                Step-by-step process
-              </h2>
-              <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                Walk through the workflow. Include prompts, commands, or configs where helpful.
-              </p>
-            </div>
-
-            <div className="space-y-4">
-              {form.steps.map((s, i) => (
-                <div
-                  key={i}
-                  className="p-5 rounded-xl relative"
-                  style={{
-                    background: "var(--bg-surface)",
-                    border: "1px solid var(--border-subtle)",
-                  }}
-                >
-                  <div className="flex items-center justify-between mb-4">
-                    <span
-                      className="flex items-center justify-center w-6 h-6 rounded-md text-xs font-bold"
-                      style={{
-                        background: "var(--accent-cyan-dim)",
-                        color: "var(--text-primary)",
-                        border: "1px solid var(--border-default)",
-                        fontFamily: "var(--font-jetbrains-mono), monospace",
-                      }}
-                    >
-                      {i + 1}
-                    </span>
-                    {form.steps.length > 1 && (
-                      <button
-                        onClick={() => removeStep(i)}
-                        className="p-1 rounded-md transition-colors"
-                        style={{ color: "var(--text-tertiary)" }}
-                      >
-                        <X className="w-3.5 h-3.5" />
-                      </button>
-                    )}
-                  </div>
-
-                  <div className="space-y-3">
-                    <input
-                      type="text"
-                      value={s.title}
-                      onChange={(e) => updateStep(i, "title", e.target.value)}
-                      placeholder="Step title"
-                      className="input-base w-full px-3.5 py-2.5 rounded-lg text-sm"
-                    />
-                    <textarea
-                      value={s.description}
-                      onChange={(e) =>
-                        updateStep(i, "description", e.target.value)
-                      }
-                      placeholder="What to do in this step..."
-                      rows={2}
-                      className="input-base w-full px-3.5 py-2.5 rounded-lg text-sm resize-none"
-                    />
-
-                    <div className="flex gap-3">
-                      {selectedToolNames.length > 0 && (
-                        <select
-                          value={s.toolName}
-                          onChange={(e) =>
-                            updateStep(i, "toolName", e.target.value)
-                          }
-                          className="input-base px-3 py-2 rounded-lg text-xs flex-1"
-                        >
-                          <option value="">Tool used (optional)</option>
-                          {selectedToolNames.map((name) => (
-                            <option key={name} value={name}>
-                              {name}
-                            </option>
-                          ))}
-                        </select>
-                      )}
-                    </div>
-
-                    <textarea
-                      value={s.promptText}
-                      onChange={(e) =>
-                        updateStep(i, "promptText", e.target.value)
-                      }
-                      placeholder="Prompt, command, or config (optional)"
-                      rows={3}
-                      className="input-base w-full px-3.5 py-2.5 rounded-lg text-xs resize-none"
-                      style={{
-                        fontFamily: "var(--font-jetbrains-mono), monospace",
-                      }}
-                    />
-                  </div>
+                  )}
                 </div>
               ))}
             </div>
@@ -662,126 +446,36 @@ export function WorkflowForm({
               <Plus className="w-3.5 h-3.5" />
               Add Step
             </button>
-          </div>
-        )}
 
-        {/* ---- STEP 4: Results & About ---- */}
-        {step === 4 && (
-          <div className="space-y-6">
+            {/* Proof URL */}
             <div>
-              <h2
-                className="text-xl font-bold mb-1"
-                style={{ fontFamily: "var(--font-syne), sans-serif" }}
-              >
-                Results & attribution
-              </h2>
-              <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                What does this workflow achieve, and who are you?
-              </p>
-            </div>
-
-            <div>
-              <Label optional>Expected Outcome</Label>
-              <textarea
-                value={form.outcome}
-                onChange={(e) => update("outcome", e.target.value)}
-                placeholder="What's the end result when this workflow is followed correctly?"
-                rows={3}
-                className="input-base w-full px-4 py-3 rounded-xl text-sm resize-none"
-              />
-            </div>
-
-            <div>
-              <Label optional>Common Pitfalls</Label>
-              <textarea
-                value={form.failureModes}
-                onChange={(e) => update("failureModes", e.target.value)}
-                placeholder="What goes wrong if someone sets this up incorrectly?"
-                rows={2}
-                className="input-base w-full px-4 py-3 rounded-xl text-sm resize-none"
-              />
-            </div>
-
-            <div>
-              <Label optional>Proof / References</Label>
-              {form.proofUrls.map((url, i) => (
-                <div key={i} className="flex items-center gap-2 mb-2">
-                  <input
-                    type="url"
-                    value={url}
-                    onChange={(e) => updateProofUrl(i, e.target.value)}
-                    placeholder="https://..."
-                    className="input-base flex-1 px-4 py-2.5 rounded-lg text-xs"
-                  />
-                  {form.proofUrls.length > 1 && (
-                    <button
-                      onClick={() => removeProofUrl(i)}
-                      className="p-1.5 rounded-md"
-                      style={{ color: "var(--text-tertiary)" }}
-                    >
-                      <X className="w-3.5 h-3.5" />
-                    </button>
-                  )}
-                </div>
-              ))}
-              <button
-                onClick={addProofUrl}
-                className="text-xs flex items-center gap-1 mt-1"
-                style={{ color: "var(--text-tertiary)" }}
-              >
-                <Plus className="w-3 h-3" />
-                Add URL
-              </button>
-            </div>
-
-            <div
-              className="pt-6"
-              style={{ borderTop: "1px solid var(--border-subtle)" }}
-            >
-              <Label>Your Name</Label>
+              <Label optional>Proof / Reference URL</Label>
               <input
-                type="text"
-                value={form.submitterName}
-                onChange={(e) => update("submitterName", e.target.value)}
-                placeholder="How you want to be credited"
-                className="input-base w-full px-4 py-3 rounded-xl text-sm mb-4"
-              />
-
-              <Label optional>Role / Company</Label>
-              <input
-                type="text"
-                value={form.submitterRole}
-                onChange={(e) => update("submitterRole", e.target.value)}
-                placeholder="e.g., Senior Engineer @ Vercel"
-                className="input-base w-full px-4 py-3 rounded-xl text-sm"
+                type="url"
+                value={form.proofUrl}
+                onChange={(e) => update("proofUrl", e.target.value)}
+                placeholder="e.g., https://github.com/your-repo or blog post link"
+                className="input-base w-full px-4 py-2.5 rounded-xl text-sm"
               />
             </div>
-          </div>
-        )}
 
-        {/* ---- STEP 5: Review ---- */}
-        {step === 5 && (
-          <div className="space-y-6">
-            <div>
-              <h2
-                className="text-xl font-bold mb-1"
-                style={{ fontFamily: "var(--font-syne), sans-serif" }}
-              >
-                Review & submit
-              </h2>
-              <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                Check everything looks good before publishing.
-              </p>
-            </div>
-
-            {/* Preview card */}
+            {/* Preview */}
             <div
-              className="p-6 rounded-xl space-y-4"
+              className="p-5 rounded-xl space-y-3"
               style={{
                 background: "var(--bg-surface)",
                 border: "1px solid var(--border-subtle)",
               }}
             >
+              <p
+                className="text-[10px] font-semibold uppercase tracking-widest"
+                style={{
+                  color: "var(--text-tertiary)",
+                  fontFamily: "var(--font-jetbrains-mono), monospace",
+                }}
+              >
+                Preview
+              </p>
               <div className="flex items-center gap-2 flex-wrap">
                 <span
                   className="px-2 py-0.5 text-[10px] font-semibold rounded-md uppercase tracking-wider"
@@ -802,30 +496,19 @@ export function WorkflowForm({
                 >
                   {form.difficulty}
                 </span>
-                {form.timeSaved && (
-                  <span
-                    className="text-[11px]"
-                    style={{ color: "var(--accent-green)" }}
-                  >
-                    Saves {form.timeSaved}
-                  </span>
-                )}
               </div>
-
               <h3
-                className="text-lg font-bold"
+                className="text-base font-bold"
                 style={{ fontFamily: "var(--font-syne), sans-serif" }}
               >
                 {form.title || "Untitled Workflow"}
               </h3>
-
               <p
                 className="text-sm leading-relaxed"
                 style={{ color: "var(--text-secondary)" }}
               >
                 {form.description || "No description"}
               </p>
-
               {form.selectedTools.length > 0 && (
                 <div className="flex flex-wrap gap-1.5">
                   {form.selectedTools.map((t) => (
@@ -843,68 +526,10 @@ export function WorkflowForm({
                   ))}
                 </div>
               )}
-
-              <div
-                className="pt-3 flex items-center gap-2"
-                style={{ borderTop: "1px solid var(--border-subtle)" }}
-              >
-                <div
-                  className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold"
-                  style={{
-                    background: "var(--accent-violet-dim)",
-                    color: "var(--accent-violet)",
-                  }}
-                >
-                  {(form.submitterName || "?").charAt(0).toUpperCase()}
-                </div>
-                <span className="text-xs font-medium">
-                  {form.submitterName || "Anonymous"}
-                </span>
-                {form.submitterRole && (
-                  <span
-                    className="text-[10px]"
-                    style={{ color: "var(--text-tertiary)" }}
-                  >
-                    {form.submitterRole}
-                  </span>
-                )}
-              </div>
-            </div>
-
-            {/* Steps summary */}
-            <div>
-              <p
-                className="text-xs font-semibold uppercase tracking-widest mb-3"
-                style={{
-                  color: "var(--text-tertiary)",
-                  fontFamily: "var(--font-jetbrains-mono), monospace",
-                }}
-              >
-                {form.steps.filter((s) => s.title || s.description).length}{" "}
-                steps
+              <p className="text-[11px]" style={{ color: "var(--text-tertiary)" }}>
+                {form.steps.filter((s) => s.trim()).length} step
+                {form.steps.filter((s) => s.trim()).length !== 1 ? "s" : ""}
               </p>
-              <ol className="space-y-2">
-                {form.steps
-                  .filter((s) => s.title || s.description)
-                  .map((s, i) => (
-                    <li
-                      key={i}
-                      className="flex items-start gap-3 text-sm"
-                      style={{ color: "var(--text-secondary)" }}
-                    >
-                      <span
-                        className="text-[10px] font-bold mt-0.5 shrink-0"
-                        style={{
-                          color: "var(--text-tertiary)",
-                          fontFamily: "var(--font-jetbrains-mono), monospace",
-                        }}
-                      >
-                        {String(i + 1).padStart(2, "0")}
-                      </span>
-                      <span>{s.title || s.description}</span>
-                    </li>
-                  ))}
-              </ol>
             </div>
 
             {error && (
@@ -924,7 +549,10 @@ export function WorkflowForm({
       </div>
 
       {/* Navigation */}
-      <div className="flex items-center justify-between mt-10 pt-6" style={{ borderTop: "1px solid var(--border-subtle)" }}>
+      <div
+        className="flex items-center justify-between mt-10 pt-6"
+        style={{ borderTop: "1px solid var(--border-subtle)" }}
+      >
         {step > 1 ? (
           <button
             onClick={() => setStep(step - 1)}
@@ -937,7 +565,7 @@ export function WorkflowForm({
           <div />
         )}
 
-        {step < 5 ? (
+        {step < 2 ? (
           <button
             onClick={() => setStep(step + 1)}
             disabled={!canAdvance()}
@@ -950,7 +578,7 @@ export function WorkflowForm({
         ) : (
           <button
             onClick={handleSubmit}
-            disabled={submitting}
+            disabled={submitting || !canSubmit()}
             className="btn-primary px-6 py-2.5 rounded-lg text-sm inline-flex items-center gap-2"
             style={{ fontFamily: "var(--font-syne), sans-serif" }}
           >
@@ -988,9 +616,7 @@ function Label({
     >
       {children}
       {optional && (
-        <span className="ml-1.5 normal-case tracking-normal font-normal">
-          (optional)
-        </span>
+        <span className="ml-1.5 normal-case tracking-normal font-normal">(optional)</span>
       )}
     </label>
   );


### PR DESCRIPTION
## Summary
- Reduces workflow submission from 5 steps to 2 steps to lower the barrier to contribution
- **Step 1**: Title, description, difficulty, and tag-style tool picker with search
- **Step 2**: Simple text-based step list + optional proof URL + preview card + submit
- Removed: problem context, time saved, failure modes, outcome, submitter name/role, per-step tool/prompt fields
- API defaults `submitterName` to "Anonymous" when not provided
- Fully backward compatible with existing workflow data in the DB

Closes #35

## Test plan
- [x] `npm run lint` passes (no new errors)
- [x] `npm run test` passes (76/76 tests)
- [x] `npm run build` succeeds
- [ ] Browser-test the 2-step submit form at `/submit`
- [ ] Verify existing workflow detail pages still render correctly at `/workflows/[slug]`
- [ ] Submit a test workflow and confirm it appears in the listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)